### PR TITLE
Fix ConjNoTrans handling and add DRY tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Examples
+name: CI
 
 on:
   push:
@@ -7,6 +7,34 @@ on:
     branches: [main]
 
 jobs:
+  rust-tests:
+    name: Rust Integration Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install OpenBLAS (Ubuntu)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
+
+      - name: Install OpenBLAS (macOS)
+        if: runner.os == 'macOS'
+        run: brew install openblas
+
+      - name: Run Rust tests
+        run: cargo test --release
+        env:
+          # For linking OpenBLAS on macOS
+          LIBRARY_PATH: /opt/homebrew/opt/openblas/lib:/usr/local/opt/openblas/lib
+
   openblas-ctest:
     name: OpenBLAS ctest
     runs-on: ${{ matrix.os }}

--- a/src/blas2/tbmv.rs
+++ b/src/blas2/tbmv.rs
@@ -11,9 +11,9 @@ use num_complex::{Complex32, Complex64};
 
 use crate::backend::{get_ctbmv, get_dtbmv, get_stbmv, get_ztbmv};
 use crate::types::{
-    blasint, diag_to_char, transpose_to_char, uplo_to_char, CblasColMajor, CblasConjTrans,
-    CblasLower, CblasNoTrans, CblasRowMajor, CblasTrans, CblasUpper, CBLAS_DIAG, CBLAS_ORDER,
-    CBLAS_TRANSPOSE, CBLAS_UPLO,
+    blasint, diag_to_char, normalize_transpose_real, transpose_to_char, uplo_to_char, CblasColMajor,
+    CblasConjNoTrans, CblasConjTrans, CblasLower, CblasNoTrans, CblasRowMajor, CblasTrans,
+    CblasUpper, CBLAS_DIAG, CBLAS_ORDER, CBLAS_TRANSPOSE, CBLAS_UPLO,
 };
 
 /// Single precision triangular band matrix-vector multiply.
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn cblas_stbmv(
     match order {
         CblasColMajor => {
             let uplo_char = uplo_to_char(uplo);
-            let trans_char = transpose_to_char(trans);
+            let trans_char = transpose_to_char(normalize_transpose_real(trans));
             let diag_char = diag_to_char(diag);
             stbmv(&uplo_char, &trans_char, &diag_char, &n, &k, a, &lda, x, &incx);
         }
@@ -54,10 +54,10 @@ pub unsafe extern "C" fn cblas_stbmv(
                 CblasUpper => CblasLower,
                 CblasLower => CblasUpper,
             };
-            let new_trans = match trans {
+            let new_trans = match normalize_transpose_real(trans) {
                 CblasNoTrans => CblasTrans,
                 CblasTrans => CblasNoTrans,
-                CblasConjTrans => CblasNoTrans, // For real types, ConjTrans = Trans
+                _ => unreachable!(),
             };
             let uplo_char = uplo_to_char(new_uplo);
             let trans_char = transpose_to_char(new_trans);
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn cblas_dtbmv(
     match order {
         CblasColMajor => {
             let uplo_char = uplo_to_char(uplo);
-            let trans_char = transpose_to_char(trans);
+            let trans_char = transpose_to_char(normalize_transpose_real(trans));
             let diag_char = diag_to_char(diag);
             dtbmv(&uplo_char, &trans_char, &diag_char, &n, &k, a, &lda, x, &incx);
         }
@@ -104,10 +104,10 @@ pub unsafe extern "C" fn cblas_dtbmv(
                 CblasUpper => CblasLower,
                 CblasLower => CblasUpper,
             };
-            let new_trans = match trans {
+            let new_trans = match normalize_transpose_real(trans) {
                 CblasNoTrans => CblasTrans,
                 CblasTrans => CblasNoTrans,
-                CblasConjTrans => CblasNoTrans, // For real types, ConjTrans = Trans
+                _ => unreachable!(),
             };
             let uplo_char = uplo_to_char(new_uplo);
             let trans_char = transpose_to_char(new_trans);
@@ -150,7 +150,7 @@ pub unsafe extern "C" fn cblas_ctbmv(
         }
         CblasRowMajor => {
             // Row-major: invert uplo and trans
-            // For complex: ConjTrans stays ConjTrans (conjugate is preserved)
+            // For complex: flip transpose with conjugation preserved (OpenBLAS)
             let new_uplo = match uplo {
                 CblasUpper => CblasLower,
                 CblasLower => CblasUpper,
@@ -158,7 +158,8 @@ pub unsafe extern "C" fn cblas_ctbmv(
             let new_trans = match trans {
                 CblasNoTrans => CblasTrans,
                 CblasTrans => CblasNoTrans,
-                CblasConjTrans => CblasConjTrans, // Conjugate transpose stays as conj trans for complex
+                CblasConjNoTrans => CblasConjTrans,
+                CblasConjTrans => CblasConjNoTrans,
             };
             let uplo_char = uplo_to_char(new_uplo);
             let trans_char = transpose_to_char(new_trans);
@@ -201,7 +202,7 @@ pub unsafe extern "C" fn cblas_ztbmv(
         }
         CblasRowMajor => {
             // Row-major: invert uplo and trans
-            // For complex: ConjTrans stays ConjTrans (conjugate is preserved)
+            // For complex: flip transpose with conjugation preserved (OpenBLAS)
             let new_uplo = match uplo {
                 CblasUpper => CblasLower,
                 CblasLower => CblasUpper,
@@ -209,7 +210,8 @@ pub unsafe extern "C" fn cblas_ztbmv(
             let new_trans = match trans {
                 CblasNoTrans => CblasTrans,
                 CblasTrans => CblasNoTrans,
-                CblasConjTrans => CblasConjTrans, // Conjugate transpose stays as conj trans for complex
+                CblasConjNoTrans => CblasConjTrans,
+                CblasConjTrans => CblasConjNoTrans,
             };
             let uplo_char = uplo_to_char(new_uplo);
             let trans_char = transpose_to_char(new_trans);

--- a/src/blas2/tbsv.rs
+++ b/src/blas2/tbsv.rs
@@ -12,9 +12,9 @@ use num_complex::{Complex32, Complex64};
 
 use crate::backend::{get_ctbsv, get_dtbsv, get_stbsv, get_ztbsv};
 use crate::types::{
-    blasint, diag_to_char, transpose_to_char, uplo_to_char, CblasColMajor, CblasConjTrans,
-    CblasLower, CblasNoTrans, CblasRowMajor, CblasTrans, CblasUpper, CBLAS_DIAG, CBLAS_ORDER,
-    CBLAS_TRANSPOSE, CBLAS_UPLO,
+    blasint, diag_to_char, normalize_transpose_real, transpose_to_char, uplo_to_char, CblasColMajor,
+    CblasConjNoTrans, CblasConjTrans, CblasLower, CblasNoTrans, CblasRowMajor, CblasTrans,
+    CblasUpper, CBLAS_DIAG, CBLAS_ORDER, CBLAS_TRANSPOSE, CBLAS_UPLO,
 };
 
 /// Single precision triangular band solve.
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn cblas_stbsv(
     match order {
         CblasColMajor => {
             let uplo_char = uplo_to_char(uplo);
-            let trans_char = transpose_to_char(trans);
+            let trans_char = transpose_to_char(normalize_transpose_real(trans));
             let diag_char = diag_to_char(diag);
             stbsv(&uplo_char, &trans_char, &diag_char, &n, &k, a, &lda, x, &incx);
         }
@@ -55,10 +55,10 @@ pub unsafe extern "C" fn cblas_stbsv(
                 CblasUpper => CblasLower,
                 CblasLower => CblasUpper,
             };
-            let new_trans = match trans {
+            let new_trans = match normalize_transpose_real(trans) {
                 CblasNoTrans => CblasTrans,
                 CblasTrans => CblasNoTrans,
-                CblasConjTrans => CblasNoTrans, // For real types, ConjTrans = Trans
+                _ => unreachable!(),
             };
             let uplo_char = uplo_to_char(new_uplo);
             let trans_char = transpose_to_char(new_trans);
@@ -95,7 +95,7 @@ pub unsafe extern "C" fn cblas_dtbsv(
     match order {
         CblasColMajor => {
             let uplo_char = uplo_to_char(uplo);
-            let trans_char = transpose_to_char(trans);
+            let trans_char = transpose_to_char(normalize_transpose_real(trans));
             let diag_char = diag_to_char(diag);
             dtbsv(&uplo_char, &trans_char, &diag_char, &n, &k, a, &lda, x, &incx);
         }
@@ -105,10 +105,10 @@ pub unsafe extern "C" fn cblas_dtbsv(
                 CblasUpper => CblasLower,
                 CblasLower => CblasUpper,
             };
-            let new_trans = match trans {
+            let new_trans = match normalize_transpose_real(trans) {
                 CblasNoTrans => CblasTrans,
                 CblasTrans => CblasNoTrans,
-                CblasConjTrans => CblasNoTrans, // For real types, ConjTrans = Trans
+                _ => unreachable!(),
             };
             let uplo_char = uplo_to_char(new_uplo);
             let trans_char = transpose_to_char(new_trans);
@@ -151,7 +151,7 @@ pub unsafe extern "C" fn cblas_ctbsv(
         }
         CblasRowMajor => {
             // Row-major: invert uplo and trans
-            // For complex: ConjTrans stays ConjTrans (conjugate is preserved)
+            // For complex: flip transpose with conjugation preserved (OpenBLAS)
             let new_uplo = match uplo {
                 CblasUpper => CblasLower,
                 CblasLower => CblasUpper,
@@ -159,7 +159,8 @@ pub unsafe extern "C" fn cblas_ctbsv(
             let new_trans = match trans {
                 CblasNoTrans => CblasTrans,
                 CblasTrans => CblasNoTrans,
-                CblasConjTrans => CblasConjTrans, // Conjugate transpose stays as conj trans for complex
+                CblasConjNoTrans => CblasConjTrans,
+                CblasConjTrans => CblasConjNoTrans,
             };
             let uplo_char = uplo_to_char(new_uplo);
             let trans_char = transpose_to_char(new_trans);
@@ -202,7 +203,7 @@ pub unsafe extern "C" fn cblas_ztbsv(
         }
         CblasRowMajor => {
             // Row-major: invert uplo and trans
-            // For complex: ConjTrans stays ConjTrans (conjugate is preserved)
+            // For complex: flip transpose with conjugation preserved (OpenBLAS)
             let new_uplo = match uplo {
                 CblasUpper => CblasLower,
                 CblasLower => CblasUpper,
@@ -210,7 +211,8 @@ pub unsafe extern "C" fn cblas_ztbsv(
             let new_trans = match trans {
                 CblasNoTrans => CblasTrans,
                 CblasTrans => CblasNoTrans,
-                CblasConjTrans => CblasConjTrans, // Conjugate transpose stays as conj trans for complex
+                CblasConjNoTrans => CblasConjTrans,
+                CblasConjTrans => CblasConjNoTrans,
             };
             let uplo_char = uplo_to_char(new_uplo);
             let trans_char = transpose_to_char(new_trans);

--- a/src/blas2/trmv.rs
+++ b/src/blas2/trmv.rs
@@ -11,9 +11,9 @@ use num_complex::{Complex32, Complex64};
 
 use crate::backend::{get_ctrmv, get_dtrmv, get_strmv, get_ztrmv};
 use crate::types::{
-    blasint, diag_to_char, transpose_to_char, uplo_to_char, CblasColMajor, CblasConjTrans,
-    CblasLower, CblasNoTrans, CblasRowMajor, CblasTrans, CblasUpper, CBLAS_DIAG, CBLAS_ORDER,
-    CBLAS_TRANSPOSE, CBLAS_UPLO,
+    blasint, diag_to_char, normalize_transpose_real, transpose_to_char, uplo_to_char,
+    CblasColMajor, CblasConjNoTrans, CblasConjTrans, CblasLower, CblasNoTrans, CblasRowMajor,
+    CblasTrans, CblasUpper, CBLAS_DIAG, CBLAS_ORDER, CBLAS_TRANSPOSE, CBLAS_UPLO,
 };
 
 /// Single precision triangular matrix-vector multiply.
@@ -42,7 +42,7 @@ pub unsafe extern "C" fn cblas_strmv(
     match order {
         CblasColMajor => {
             let uplo_char = uplo_to_char(uplo);
-            let trans_char = transpose_to_char(trans);
+            let trans_char = transpose_to_char(normalize_transpose_real(trans));
             let diag_char = diag_to_char(diag);
             strmv(&uplo_char, &trans_char, &diag_char, &n, a, &lda, x, &incx);
         }
@@ -53,10 +53,10 @@ pub unsafe extern "C" fn cblas_strmv(
                 CblasUpper => CblasLower,
                 CblasLower => CblasUpper,
             };
-            let new_trans = match trans {
+            let new_trans = match normalize_transpose_real(trans) {
                 CblasNoTrans => CblasTrans,
                 CblasTrans => CblasNoTrans,
-                CblasConjTrans => CblasNoTrans, // For real types, ConjTrans = Trans
+                _ => unreachable!(),
             };
             let uplo_char = uplo_to_char(new_uplo);
             let trans_char = transpose_to_char(new_trans);
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn cblas_dtrmv(
     match order {
         CblasColMajor => {
             let uplo_char = uplo_to_char(uplo);
-            let trans_char = transpose_to_char(trans);
+            let trans_char = transpose_to_char(normalize_transpose_real(trans));
             let diag_char = diag_to_char(diag);
             dtrmv(&uplo_char, &trans_char, &diag_char, &n, a, &lda, x, &incx);
         }
@@ -102,10 +102,10 @@ pub unsafe extern "C" fn cblas_dtrmv(
                 CblasUpper => CblasLower,
                 CblasLower => CblasUpper,
             };
-            let new_trans = match trans {
+            let new_trans = match normalize_transpose_real(trans) {
                 CblasNoTrans => CblasTrans,
                 CblasTrans => CblasNoTrans,
-                CblasConjTrans => CblasNoTrans, // For real types, ConjTrans = Trans
+                _ => unreachable!(),
             };
             let uplo_char = uplo_to_char(new_uplo);
             let trans_char = transpose_to_char(new_trans);
@@ -155,7 +155,8 @@ pub unsafe extern "C" fn cblas_ctrmv(
             let new_trans = match trans {
                 CblasNoTrans => CblasTrans,
                 CblasTrans => CblasNoTrans,
-                CblasConjTrans => CblasConjTrans, // Conjugate transpose stays as conj trans for complex
+                CblasConjNoTrans => CblasConjTrans,
+                CblasConjTrans => CblasConjNoTrans,
             };
             let uplo_char = uplo_to_char(new_uplo);
             let trans_char = transpose_to_char(new_trans);
@@ -197,7 +198,7 @@ pub unsafe extern "C" fn cblas_ztrmv(
         }
         CblasRowMajor => {
             // Row-major: invert uplo and trans
-            // For complex: ConjTrans stays ConjTrans (conjugate is preserved)
+            // For complex: flip transpose with conjugation preserved (OpenBLAS)
             let new_uplo = match uplo {
                 CblasUpper => CblasLower,
                 CblasLower => CblasUpper,
@@ -205,7 +206,8 @@ pub unsafe extern "C" fn cblas_ztrmv(
             let new_trans = match trans {
                 CblasNoTrans => CblasTrans,
                 CblasTrans => CblasNoTrans,
-                CblasConjTrans => CblasConjTrans, // Conjugate transpose stays as conj trans for complex
+                CblasConjNoTrans => CblasConjTrans,
+                CblasConjTrans => CblasConjNoTrans,
             };
             let uplo_char = uplo_to_char(new_uplo);
             let trans_char = transpose_to_char(new_trans);

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,9 +35,14 @@ pub enum CBLAS_TRANSPOSE {
     CblasTrans = 112,
     /// Conjugate transpose (Hermitian)
     CblasConjTrans = 113,
+    /// Conjugate, no transpose (CBLAS extension used by OpenBLAS: maps to Fortran 'R')
+    ///
+    /// Note: This is distinct from `CblasNoTrans` for complex-valued operations.
+    /// For real-valued operations, it is equivalent to `CblasNoTrans`.
+    CblasConjNoTrans = 114,
 }
 
-pub use CBLAS_TRANSPOSE::{CblasConjTrans, CblasNoTrans, CblasTrans};
+pub use CBLAS_TRANSPOSE::{CblasConjNoTrans, CblasConjTrans, CblasNoTrans, CblasTrans};
 
 /// Upper/Lower triangle selector for symmetric/triangular operations.
 #[repr(C)]
@@ -90,6 +95,19 @@ pub(crate) fn transpose_to_char(trans: CBLAS_TRANSPOSE) -> c_char {
         CblasNoTrans => b'N' as c_char,
         CblasTrans => b'T' as c_char,
         CblasConjTrans => b'C' as c_char,
+        CblasConjNoTrans => b'R' as c_char,
+    }
+}
+
+/// Normalize transpose mode for real-valued BLAS operations.
+///
+/// - `CblasConjTrans` behaves like `CblasTrans`
+/// - `CblasConjNoTrans` behaves like `CblasNoTrans`
+#[inline]
+pub(crate) fn normalize_transpose_real(trans: CBLAS_TRANSPOSE) -> CBLAS_TRANSPOSE {
+    match trans {
+        CblasNoTrans | CblasConjNoTrans => CblasNoTrans,
+        CblasTrans | CblasConjTrans => CblasTrans,
     }
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,646 @@
+//! Common test utilities for CBLAS tests.
+#![allow(dead_code)]
+//!
+//! Provides data generation, comparison functions, and helper utilities
+//! for testing cblas-inject against OpenBLAS reference implementation.
+
+use cblas_inject::{
+    blasint, CblasColMajor, CblasRowMajor, CBLAS_ORDER, CBLAS_TRANSPOSE, CBLAS_UPLO,
+};
+use num_complex::{Complex32, Complex64};
+
+/// CBLAS enum values for OpenBLAS FFI (u32)
+pub const CBLAS_ROW_MAJOR: u32 = 101;
+pub const CBLAS_COL_MAJOR: u32 = 102;
+pub const CBLAS_NO_TRANS: u32 = 111;
+pub const CBLAS_TRANS: u32 = 112;
+pub const CBLAS_CONJ_TRANS: u32 = 113;
+pub const CBLAS_CONJ_NO_TRANS: u32 = 114;
+
+/// Convert CBLAS_ORDER to u32 for OpenBLAS FFI
+pub fn order_to_u32(order: CBLAS_ORDER) -> u32 {
+    match order {
+        CblasRowMajor => CBLAS_ROW_MAJOR,
+        CblasColMajor => CBLAS_COL_MAJOR,
+    }
+}
+
+/// Convert CBLAS_TRANSPOSE to u32 for OpenBLAS FFI
+pub fn transpose_to_u32(trans: CBLAS_TRANSPOSE) -> u32 {
+    match trans {
+        cblas_inject::CblasNoTrans => CBLAS_NO_TRANS,
+        cblas_inject::CblasTrans => CBLAS_TRANS,
+        cblas_inject::CblasConjTrans => CBLAS_CONJ_TRANS,
+        cblas_inject::CblasConjNoTrans => CBLAS_CONJ_NO_TRANS,
+    }
+}
+
+/// Generate test matrix data (real)
+#[allow(dead_code)]
+pub fn generate_matrix_f64(rows: usize, cols: usize, seed: usize) -> Vec<f64> {
+    (0..rows * cols)
+        .map(|i| ((i + seed) as f64 * 0.1).sin())
+        .collect()
+}
+
+/// Generate test matrix data (complex)
+pub fn generate_matrix_complex64(rows: usize, cols: usize, seed: usize) -> Vec<Complex64> {
+    (0..rows * cols)
+        .map(|i| {
+            Complex64::new(
+                ((i + seed) as f64 * 0.1).sin(),
+                ((i + seed) as f64 * 0.2).cos(),
+            )
+        })
+        .collect()
+}
+
+/// Generate test matrix data (complex32)
+pub fn generate_matrix_complex32(rows: usize, cols: usize, seed: usize) -> Vec<Complex32> {
+    (0..rows * cols)
+        .map(|i| {
+            Complex32::new(
+                ((i + seed) as f32 * 0.1).sin(),
+                ((i + seed) as f32 * 0.2).cos(),
+            )
+        })
+        .collect()
+}
+
+/// Generate test vector data (real)
+#[allow(dead_code)]
+pub fn generate_vector_f64(len: usize, seed: usize) -> Vec<f64> {
+    (0..len)
+        .map(|i| ((i + seed) as f64 * 0.15).cos())
+        .collect()
+}
+
+/// Generate test vector data (complex64)
+pub fn generate_vector_complex64(len: usize, seed: usize) -> Vec<Complex64> {
+    (0..len)
+        .map(|i| {
+            Complex64::new(
+                ((i + seed) as f64 * 0.15).cos(),
+                ((i + seed) as f64 * 0.25).sin(),
+            )
+        })
+        .collect()
+}
+
+/// Generate test vector data (complex32)
+pub fn generate_vector_complex32(len: usize, seed: usize) -> Vec<Complex32> {
+    (0..len)
+        .map(|i| {
+            Complex32::new(
+                ((i + seed) as f32 * 0.15).cos(),
+                ((i + seed) as f32 * 0.25).sin(),
+            )
+        })
+        .collect()
+}
+
+/// Calculate leading dimension for a matrix (GEMV-like operations)
+///
+/// OpenBLAS CBLAS semantics for GEMV:
+/// - ColMajor: `lda` is the leading dimension of the *original* A(m×n) and must satisfy `lda >= max(1, m)`,
+///            independent of `trans`.
+/// - RowMajor: OpenBLAS swaps `m/n` internally and checks `lda >= max(1, swapped_m)` where `swapped_m = n`,
+///            so `lda >= max(1, n)` independent of `trans`.
+pub fn calc_lda_gemv(
+    order: CBLAS_ORDER,
+    trans: CBLAS_TRANSPOSE,
+    m: usize,
+    n: usize,
+) -> blasint {
+    match order {
+        // RowMajor: lda >= n (after OpenBLAS swap)
+        CblasRowMajor => n as blasint,
+        // ColMajor: lda >= m (independent of trans)
+        CblasColMajor => {
+            let _ = trans; // keep signature symmetric; trans does not affect lda for CBLAS GEMV
+            m as blasint
+        }
+    }
+}
+
+/// Calculate leading dimension for a band matrix (GBMV-like operations)
+#[allow(dead_code)]
+pub fn calc_lda_gbmv(kl: usize, ku: usize) -> blasint {
+    (kl + ku + 1) as blasint
+}
+
+/// Calculate vector length for GEMV output
+pub fn calc_output_len_gemv(trans: CBLAS_TRANSPOSE, m: usize, n: usize) -> usize {
+    match trans {
+        cblas_inject::CblasNoTrans | cblas_inject::CblasConjNoTrans => m,
+        cblas_inject::CblasTrans | cblas_inject::CblasConjTrans => n,
+    }
+}
+
+/// Calculate input vector length for GEMV/GBMV based on transpose.
+pub fn x_len_gemv(trans: CBLAS_TRANSPOSE, m: usize, n: usize) -> usize {
+    match trans {
+        cblas_inject::CblasNoTrans => n,
+        cblas_inject::CblasTrans | cblas_inject::CblasConjTrans => m,
+        #[allow(unreachable_patterns)]
+        _ => n,
+    }
+}
+
+/// Calculate output vector length for GEMV/GBMV based on transpose.
+pub fn y_len_gemv(trans: CBLAS_TRANSPOSE, m: usize, n: usize) -> usize {
+    match trans {
+        cblas_inject::CblasNoTrans => m,
+        cblas_inject::CblasTrans | cblas_inject::CblasConjTrans => n,
+        #[allow(unreachable_patterns)]
+        _ => m,
+    }
+}
+
+/// Calculate vector storage size given length and stride
+/// For BLAS, storage size is: 1 + (n - 1) * abs(inc)
+pub fn calc_vector_storage_size(len: usize, inc: blasint) -> usize {
+    if len == 0 {
+        0
+    } else {
+        1 + (len - 1) * (inc.abs() as usize)
+    }
+}
+
+/// Compare two f64 slices with tolerance
+#[allow(dead_code)]
+pub fn assert_f64_eq(got: &[f64], expected: &[f64], tol: f64, context: &str) {
+    assert_eq!(
+        got.len(),
+        expected.len(),
+        "{}: length mismatch: got {}, expected {}",
+        context,
+        got.len(),
+        expected.len()
+    );
+    for (i, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+        let diff = (g - e).abs();
+        let scale = e.abs().max(1.0);
+        assert!(
+            diff < tol * scale,
+            "{}: mismatch at index {}: got {}, expected {}, diff {}",
+            context,
+            i,
+            g,
+            e,
+            diff
+        );
+    }
+}
+
+/// Compare two Complex64 slices with tolerance
+pub fn assert_complex64_eq(
+    got: &[Complex64],
+    expected: &[Complex64],
+    tol: f64,
+    context: &str,
+) {
+    assert_eq!(
+        got.len(),
+        expected.len(),
+        "{}: length mismatch: got {}, expected {}",
+        context,
+        got.len(),
+        expected.len()
+    );
+    for (i, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+        let diff = (g - e).norm();
+        let scale = e.norm().max(1.0);
+        assert!(
+            diff < tol * scale,
+            "{}: mismatch at index {}: got {:?}, expected {:?}, diff {}",
+            context,
+            i,
+            g,
+            e,
+            diff
+        );
+    }
+}
+
+/// Compare two Complex32 slices with tolerance
+pub fn assert_complex32_eq(
+    got: &[Complex32],
+    expected: &[Complex32],
+    tol: f32,
+    context: &str,
+) {
+    assert_eq!(
+        got.len(),
+        expected.len(),
+        "{}: length mismatch: got {}, expected {}",
+        context,
+        got.len(),
+        expected.len()
+    );
+    for (i, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+        let diff = (g - e).norm();
+        let scale = e.norm().max(1.0);
+        assert!(
+            diff < tol * scale,
+            "{}: mismatch at index {}: got {:?}, expected {:?}, diff {}",
+            context,
+            i,
+            g,
+            e,
+            diff
+        );
+    }
+}
+
+/// Compare two Complex32 vectors with stride (for testing with inc != 1)
+pub fn assert_complex32_eq_strided(
+    got: &[Complex32],
+    expected: &[Complex32],
+    len: usize,
+    inc: blasint,
+    tol: f32,
+    context: &str,
+) {
+    let inc_abs = inc.abs() as usize;
+    for i in 0..len {
+        let got_idx = i * inc_abs;
+        let exp_idx = i * inc_abs;
+        if got_idx >= got.len() || exp_idx >= expected.len() {
+            panic!(
+                "{}: index out of bounds: got_idx={}, exp_idx={}, got_len={}, exp_len={}",
+                context,
+                got_idx,
+                exp_idx,
+                got.len(),
+                expected.len()
+            );
+        }
+        let g = got[got_idx];
+        let e = expected[exp_idx];
+        let diff = (g - e).norm();
+        let scale = e.norm().max(1.0);
+        assert!(
+            diff < tol * scale,
+            "{}: mismatch at element {} (index {}): got {:?}, expected {:?}, diff {}",
+            context,
+            i,
+            got_idx,
+            g,
+            e,
+            diff
+        );
+    }
+}
+
+// =============================================================================
+// Macro helpers
+// =============================================================================
+
+/// Define a one-time setup function for registering a BLAS symbol.
+#[macro_export]
+macro_rules! setup_once {
+    ($name:ident, $register:path, $symbol:ident) => {
+        fn $name() {
+            #[cfg(not(feature = "openblas"))]
+            {
+                static INIT: std::sync::Once = std::sync::Once::new();
+                INIT.call_once(|| unsafe { $register($symbol) });
+            }
+        }
+    };
+}
+
+// ============================================================================
+// Pure Rust Matrix/Vector abstractions for layout conversion tests
+// ============================================================================
+
+/// Matrix layout (RowMajor or ColMajor)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Layout {
+    RowMajor,
+    ColMajor,
+}
+
+/// Minimal matrix wrapper for pure Rust layout conversion tests.
+///
+/// - RowMajor index: `i*lda + j`, requires `lda >= cols`
+/// - ColMajor index: `i + j*lda`, requires `lda >= rows`
+pub struct Matrix<T> {
+    layout: Layout,
+    rows: usize,
+    cols: usize,
+    lda: usize,
+    data: Vec<T>,
+}
+
+impl<T: Copy> Matrix<T> {
+    /// Create a new row-major matrix with padding.
+    ///
+    /// # Panics
+    /// Panics if `lda < cols`.
+    pub fn new_row_major(rows: usize, cols: usize, lda: usize, fill: impl Fn(usize, usize) -> T) -> Self {
+        assert!(lda >= cols, "RowMajor: lda ({}) must be >= cols ({})", lda, cols);
+        let mut data = vec![fill(0, 0); rows * lda];
+        for i in 0..rows {
+            for j in 0..cols {
+                data[i * lda + j] = fill(i, j);
+            }
+        }
+        Self {
+            layout: Layout::RowMajor,
+            rows,
+            cols,
+            lda,
+            data,
+        }
+    }
+
+    /// Create a new column-major matrix with padding.
+    ///
+    /// # Panics
+    /// Panics if `lda < rows`.
+    pub fn new_col_major(rows: usize, cols: usize, lda: usize, fill: impl Fn(usize, usize) -> T) -> Self {
+        assert!(lda >= rows, "ColMajor: lda ({}) must be >= rows ({})", lda, rows);
+        let mut data = vec![fill(0, 0); lda * cols];
+        for i in 0..rows {
+            for j in 0..cols {
+                data[i + j * lda] = fill(i, j);
+            }
+        }
+        Self {
+            layout: Layout::ColMajor,
+            rows,
+            cols,
+            lda,
+            data,
+        }
+    }
+
+    /// Get element at position (i, j).
+    ///
+    /// # Panics
+    /// Panics if `i >= rows` or `j >= cols`.
+    pub fn get(&self, i: usize, j: usize) -> T {
+        assert!(i < self.rows && j < self.cols, "Index out of bounds: ({}, {}) for matrix {}x{}", i, j, self.rows, self.cols);
+        match self.layout {
+            Layout::RowMajor => self.data[i * self.lda + j],
+            Layout::ColMajor => self.data[i + j * self.lda],
+        }
+    }
+
+    /// Convert matrix to a different layout with a new LDA.
+    pub fn to_layout(&self, layout: Layout, lda: usize) -> Matrix<T> {
+        match layout {
+            Layout::RowMajor => Matrix::new_row_major(self.rows, self.cols, lda, |i, j| self.get(i, j)),
+            Layout::ColMajor => Matrix::new_col_major(self.rows, self.cols, lda, |i, j| self.get(i, j)),
+        }
+    }
+
+    /// Get raw pointer to matrix data.
+    pub fn as_ptr(&self) -> *const T {
+        self.data.as_ptr()
+    }
+
+    /// Get mutable raw pointer to matrix data.
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.data.as_mut_ptr()
+    }
+
+    /// Get LDA as blasint.
+    pub fn lda_blasint(&self) -> blasint {
+        self.lda as blasint
+    }
+
+    /// Get number of rows.
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    /// Get number of columns.
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+
+    /// Get layout.
+    pub fn layout(&self) -> Layout {
+        self.layout
+    }
+}
+
+/// Strided vector wrapper for pure Rust layout conversion tests.
+pub struct StridedVec<T> {
+    data: Vec<T>,
+    len: usize,
+    inc: blasint,
+}
+
+impl<T: Copy + Default> StridedVec<T> {
+    /// Create a new strided vector.
+    ///
+    /// # Panics
+    /// Panics if `inc == 0`.
+    pub fn new(len: usize, inc: blasint, fill: impl Fn(usize) -> T) -> Self {
+        assert!(inc != 0, "Stride cannot be zero");
+        let storage_size = calc_vector_storage_size(len, inc);
+        let mut data = vec![T::default(); storage_size];
+        let inc_abs = inc.abs() as usize;
+        for i in 0..len {
+            let idx = if inc < 0 {
+                (len - 1 - i) * inc_abs
+            } else {
+                i * inc_abs
+            };
+            data[idx] = fill(i);
+        }
+        Self { data, len, inc }
+    }
+
+    /// Get raw pointer to vector data.
+    pub fn as_ptr(&self) -> *const T {
+        if self.inc < 0 && self.len > 0 {
+            // For negative stride, BLAS expects pointer to the last element
+            let inc_abs = (-self.inc) as usize;
+            unsafe { self.data.as_ptr().add((self.len - 1) * inc_abs) }
+        } else {
+            self.data.as_ptr()
+        }
+    }
+
+    /// Get mutable raw pointer to vector data.
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        if self.inc < 0 && self.len > 0 {
+            // For negative stride, BLAS expects pointer to the last element
+            let inc_abs = (-self.inc) as usize;
+            unsafe { self.data.as_mut_ptr().add((self.len - 1) * inc_abs) }
+        } else {
+            self.data.as_mut_ptr()
+        }
+    }
+
+    /// Get stride.
+    pub fn inc(&self) -> blasint {
+        self.inc
+    }
+
+    /// Get logical length.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Extract logical elements as a Vec (for comparison).
+    pub fn to_vec(&self) -> Vec<T> {
+        let mut result = Vec::with_capacity(self.len);
+        let inc_abs = self.inc.abs() as usize;
+        for i in 0..self.len {
+            let idx = if self.inc < 0 {
+                (self.len - 1 - i) * inc_abs
+            } else {
+                i * inc_abs
+            };
+            result.push(self.data[idx]);
+        }
+        result
+    }
+}
+
+// =============================================================================
+// Band/Packed matrix storage helpers
+// =============================================================================
+
+/// Create band matrix in ColMajor band storage format.
+///
+/// Band storage format (ColMajor):
+/// - LDA >= kl + ku + 1
+/// - Element (i, j) of the original matrix is stored at A[ku + i - j, j]
+/// - Only elements within the band are stored
+pub fn create_band_matrix_col<T: Copy + Default>(
+    m: usize,
+    n: usize,
+    kl: usize,
+    ku: usize,
+    fill: impl Fn(usize, usize) -> T,
+) -> Vec<T> {
+    let lda = calc_lda_gbmv(kl, ku) as usize;
+    let mut data = vec![T::default(); lda * n];
+    for j in 0..n {
+        for i in 0..m {
+            // Check if (i, j) is within the band: j - ku <= i <= j + kl
+            if i >= j.saturating_sub(ku) && i <= j + kl {
+                let band_row = ku as isize + i as isize - j as isize;
+                if band_row >= 0 && (band_row as usize) < lda {
+                    data[band_row as usize + j * lda] = fill(i, j);
+                }
+            }
+        }
+    }
+    data
+}
+
+/// Create band matrix in RowMajor band storage format.
+///
+/// For RowMajor, we swap m/n and kl/ku, then use the same band storage format.
+pub fn create_band_matrix_row<T: Copy + Default>(
+    m: usize,
+    n: usize,
+    kl: usize,
+    ku: usize,
+    fill: impl Fn(usize, usize) -> T,
+) -> Vec<T> {
+    // RowMajor: swap m/n and kl/ku
+    create_band_matrix_col(n, m, ku, kl, |i, j| fill(j, i))
+}
+
+/// Create triangular band matrix in ColMajor band storage format.
+///
+/// Band storage format (ColMajor):
+/// - LDA >= k + 1
+/// - For Upper: element (i, j) is stored at A[k + i - j, j] where j-k <= i <= j
+/// - For Lower: element (i, j) is stored at A[i - j, j] where j <= i <= j+k
+pub fn create_triangular_band_matrix_col<T: Copy + Default>(
+    n: usize,
+    k: usize,
+    uplo: CBLAS_UPLO,
+    fill: impl Fn(usize, usize) -> T,
+) -> Vec<T> {
+    let lda = k + 1;
+    let mut data = vec![T::default(); lda * n];
+    for j in 0..n {
+        match uplo {
+            cblas_inject::CblasUpper => {
+                let i_start = j.saturating_sub(k);
+                let i_end = j;
+                for i in i_start..=i_end {
+                    let band_row = k + i - j;
+                    data[band_row + j * lda] = fill(i, j);
+                }
+            }
+            cblas_inject::CblasLower => {
+                let i_start = j;
+                let i_end = (j + k).min(n - 1);
+                for i in i_start..=i_end {
+                    let band_row = i - j;
+                    data[band_row + j * lda] = fill(i, j);
+                }
+            }
+        }
+    }
+    data
+}
+
+/// Create triangular band matrix for RowMajor CBLAS call.
+pub fn create_triangular_band_matrix_row<T: Copy + Default>(
+    n: usize,
+    k: usize,
+    uplo: CBLAS_UPLO,
+    fill: impl Fn(usize, usize) -> T,
+) -> Vec<T> {
+    let swapped_uplo = match uplo {
+        cblas_inject::CblasUpper => cblas_inject::CblasLower,
+        cblas_inject::CblasLower => cblas_inject::CblasUpper,
+    };
+    create_triangular_band_matrix_col(n, k, swapped_uplo, |i, j| fill(j, i))
+}
+
+/// Create triangular packed matrix in ColMajor packed format.
+pub fn create_triangular_packed_matrix_col<T: Copy + Default>(
+    n: usize,
+    uplo: CBLAS_UPLO,
+    fill: impl Fn(usize, usize) -> T,
+) -> Vec<T> {
+    let size = n * (n + 1) / 2;
+    let mut data = vec![T::default(); size];
+    let mut idx = 0;
+    match uplo {
+        cblas_inject::CblasUpper => {
+            for j in 0..n {
+                for i in 0..=j {
+                    data[idx] = fill(i, j);
+                    idx += 1;
+                }
+            }
+        }
+        cblas_inject::CblasLower => {
+            for j in 0..n {
+                for i in j..n {
+                    data[idx] = fill(i, j);
+                    idx += 1;
+                }
+            }
+        }
+    }
+    data
+}
+
+/// Create triangular packed matrix for RowMajor CBLAS call.
+pub fn create_triangular_packed_matrix_row<T: Copy + Default>(
+    n: usize,
+    uplo: CBLAS_UPLO,
+    fill: impl Fn(usize, usize) -> T,
+) -> Vec<T> {
+    let swapped_uplo = match uplo {
+        cblas_inject::CblasUpper => cblas_inject::CblasLower,
+        cblas_inject::CblasLower => cblas_inject::CblasUpper,
+    };
+    create_triangular_packed_matrix_col(n, swapped_uplo, |i, j| fill(j, i))
+}

--- a/tests/gbmv.rs
+++ b/tests/gbmv.rs
@@ -1,0 +1,225 @@
+//! Pure-Rust layout tests for GBMV (complex types).
+//!
+//! Policy:
+//! - Do NOT modify existing OpenBLAS-derived tests.
+//! - Add additional tests that validate row-major conversion logic by comparing
+//!   `order=RowMajor` vs `order=ColMajor` results for the *same logical band matrix*.
+//!
+//! Notes:
+//! - Band matrix storage format: ColMajor uses kl+ku+1 rows, RowMajor swaps m/n and kl/ku.
+//! - These tests still use OpenBLAS as the backend BLAS (via `blas_src`) for the
+//!   registered Fortran symbols, but the *test oracle* is purely internal:
+//!   RowMajor result must equal ColMajor result after providing equivalent inputs.
+
+extern crate blas_src;
+
+use cblas_inject::{
+    blasint, register_cgbmv, register_zgbmv, CblasColMajor, CblasConjTrans, CblasNoTrans,
+    CblasRowMajor, CblasTrans,
+};
+use num_complex::{Complex32, Complex64};
+use std::ffi::c_char;
+
+#[macro_use]
+mod common;
+use common::{
+    assert_complex32_eq, assert_complex64_eq, calc_lda_gbmv, create_band_matrix_col,
+    create_band_matrix_row, x_len_gemv, y_len_gemv,
+};
+
+// Fortran BLAS function declarations (provided by linked OpenBLAS)
+extern "C" {
+    fn cgbmv_(
+        trans: *const c_char,
+        m: *const blasint,
+        n: *const blasint,
+        kl: *const blasint,
+        ku: *const blasint,
+        alpha: *const Complex32,
+        a: *const Complex32,
+        lda: *const blasint,
+        x: *const Complex32,
+        incx: *const blasint,
+        beta: *const Complex32,
+        y: *mut Complex32,
+        incy: *const blasint,
+    );
+
+    fn zgbmv_(
+        trans: *const c_char,
+        m: *const blasint,
+        n: *const blasint,
+        kl: *const blasint,
+        ku: *const blasint,
+        alpha: *const Complex64,
+        a: *const Complex64,
+        lda: *const blasint,
+        x: *const Complex64,
+        incx: *const blasint,
+        beta: *const Complex64,
+        y: *mut Complex64,
+        incy: *const blasint,
+    );
+}
+
+setup_once!(setup_cgbmv, register_cgbmv, cgbmv_);
+setup_once!(setup_zgbmv, register_zgbmv, zgbmv_);
+
+#[test]
+fn cgbmv_row_vs_col_agree() {
+    setup_cgbmv();
+
+    let cases = [
+        (3usize, 4usize, 1usize, 1usize), // m, n, kl, ku
+        (4, 3, 1, 1),
+        (5, 5, 2, 1),
+        (6, 4, 1, 2),
+    ];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let alpha = Complex32::new(0.7, 0.3);
+    let beta = Complex32::new(1.3, -0.5);
+
+    for &(m, n, kl, ku) in &cases {
+        for &trans in &transposes {
+            // Create the same logical band matrix in both layouts
+            let a_col = create_band_matrix_col(m, n, kl, ku, |i, j| {
+                Complex32::new(((i + 3 * j) as f32 * 0.1).sin(), ((7 * i + j) as f32 * 0.2).cos())
+            });
+            let a_row = create_band_matrix_row(m, n, kl, ku, |i, j| {
+                Complex32::new(((i + 3 * j) as f32 * 0.1).sin(), ((7 * i + j) as f32 * 0.2).cos())
+            });
+
+            let xl = x_len_gemv(trans, m, n);
+            let yl = y_len_gemv(trans, m, n);
+            let x: Vec<Complex32> = (0..xl)
+                .map(|k| Complex32::new(((k + 11) as f32 * 0.15).cos(), ((k + 5) as f32 * 0.25).sin()))
+                .collect();
+            let y0: Vec<Complex32> = (0..yl)
+                .map(|k| Complex32::new(((k + 17) as f32 * 0.05).sin(), ((k + 19) as f32 * 0.07).cos()))
+                .collect();
+
+            let mut y_row = y0.clone();
+            let mut y_col = y0.clone();
+
+            let lda_col = calc_lda_gbmv(kl, ku);
+            let lda_row = calc_lda_gbmv(ku, kl); // swapped kl/ku for RowMajor
+
+            unsafe {
+                cblas_inject::cblas_cgbmv(
+                    CblasRowMajor,
+                    trans,
+                    m as blasint,
+                    n as blasint,
+                    kl as blasint,
+                    ku as blasint,
+                    &alpha,
+                    a_row.as_ptr(),
+                    lda_row,
+                    x.as_ptr(),
+                    1,
+                    &beta,
+                    y_row.as_mut_ptr(),
+                    1,
+                );
+                cblas_inject::cblas_cgbmv(
+                    CblasColMajor,
+                    trans,
+                    m as blasint,
+                    n as blasint,
+                    kl as blasint,
+                    ku as blasint,
+                    &alpha,
+                    a_col.as_ptr(),
+                    lda_col,
+                    x.as_ptr(),
+                    1,
+                    &beta,
+                    y_col.as_mut_ptr(),
+                    1,
+                );
+            }
+
+            let context = format!("cgbmv row-vs-col: m={}, n={}, kl={}, ku={}, trans={:?}", m, n, kl, ku, trans);
+            assert_complex32_eq(&y_row, &y_col, 1e-5, &context);
+        }
+    }
+}
+
+#[test]
+fn zgbmv_row_vs_col_agree() {
+    setup_zgbmv();
+
+    let cases = [
+        (3usize, 4usize, 1usize, 1usize),
+        (4, 3, 1, 1),
+        (5, 5, 2, 1),
+        (6, 4, 1, 2),
+    ];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let alpha = Complex64::new(0.7, 0.3);
+    let beta = Complex64::new(1.3, -0.5);
+
+    for &(m, n, kl, ku) in &cases {
+        for &trans in &transposes {
+            let a_col = create_band_matrix_col(m, n, kl, ku, |i, j| {
+                Complex64::new(((i + 3 * j) as f64 * 0.1).sin(), ((7 * i + j) as f64 * 0.2).cos())
+            });
+            let a_row = create_band_matrix_row(m, n, kl, ku, |i, j| {
+                Complex64::new(((i + 3 * j) as f64 * 0.1).sin(), ((7 * i + j) as f64 * 0.2).cos())
+            });
+
+            let xl = x_len_gemv(trans, m, n);
+            let yl = y_len_gemv(trans, m, n);
+            let x: Vec<Complex64> = (0..xl)
+                .map(|k| Complex64::new(((k + 11) as f64 * 0.15).cos(), ((k + 5) as f64 * 0.25).sin()))
+                .collect();
+            let y0: Vec<Complex64> = (0..yl)
+                .map(|k| Complex64::new(((k + 17) as f64 * 0.05).sin(), ((k + 19) as f64 * 0.07).cos()))
+                .collect();
+
+            let mut y_row = y0.clone();
+            let mut y_col = y0.clone();
+
+            let lda_col = calc_lda_gbmv(kl, ku);
+            let lda_row = calc_lda_gbmv(ku, kl);
+
+            unsafe {
+                cblas_inject::cblas_zgbmv(
+                    CblasRowMajor,
+                    trans,
+                    m as blasint,
+                    n as blasint,
+                    kl as blasint,
+                    ku as blasint,
+                    &alpha,
+                    a_row.as_ptr(),
+                    lda_row,
+                    x.as_ptr(),
+                    1,
+                    &beta,
+                    y_row.as_mut_ptr(),
+                    1,
+                );
+                cblas_inject::cblas_zgbmv(
+                    CblasColMajor,
+                    trans,
+                    m as blasint,
+                    n as blasint,
+                    kl as blasint,
+                    ku as blasint,
+                    &alpha,
+                    a_col.as_ptr(),
+                    lda_col,
+                    x.as_ptr(),
+                    1,
+                    &beta,
+                    y_col.as_mut_ptr(),
+                    1,
+                );
+            }
+
+            let context = format!("zgbmv row-vs-col: m={}, n={}, kl={}, ku={}, trans={:?}", m, n, kl, ku, trans);
+            assert_complex64_eq(&y_row, &y_col, 1e-12, &context);
+        }
+    }
+}

--- a/tests/gemm.rs
+++ b/tests/gemm.rs
@@ -6,8 +6,8 @@
 extern crate blas_src;
 
 use cblas_inject::{
-    blasint, register_dgemm, register_zgemm, CblasColMajor, CblasConjTrans, CblasNoTrans,
-    CblasRowMajor, CblasTrans, CBLAS_ORDER, CBLAS_TRANSPOSE,
+    blasint, register_dgemm, register_zgemm, CblasColMajor, CblasConjNoTrans, CblasConjTrans,
+    CblasNoTrans, CblasRowMajor, CblasTrans, CBLAS_ORDER, CBLAS_TRANSPOSE,
 };
 use num_complex::Complex64;
 use std::ffi::c_char;
@@ -132,11 +132,11 @@ fn generate_complex_matrix(rows: usize, cols: usize, seed: usize) -> Vec<Complex
 fn calc_lda(order: CBLAS_ORDER, trans: CBLAS_TRANSPOSE, rows: usize, cols: usize) -> blasint {
     match order {
         CblasRowMajor => match trans {
-            CblasNoTrans => cols as blasint,
+            CblasNoTrans | CblasConjNoTrans => cols as blasint,
             CblasTrans | CblasConjTrans => rows as blasint,
         },
         CblasColMajor => match trans {
-            CblasNoTrans => rows as blasint,
+            CblasNoTrans | CblasConjNoTrans => rows as blasint,
             CblasTrans | CblasConjTrans => cols as blasint,
         },
     }
@@ -227,12 +227,13 @@ fn test_dgemm_case(
     beta: f64,
 ) {
     // Determine matrix dimensions based on transpose
+    // For real types, ConjNoTrans = NoTrans, ConjTrans = Trans
     let (a_rows, a_cols) = match transa {
-        CblasNoTrans => (m, k),
+        CblasNoTrans | CblasConjNoTrans => (m, k),
         CblasTrans | CblasConjTrans => (k, m),
     };
     let (b_rows, b_cols) = match transb {
-        CblasNoTrans => (k, n),
+        CblasNoTrans | CblasConjNoTrans => (k, n),
         CblasTrans | CblasConjTrans => (n, k),
     };
 
@@ -356,12 +357,13 @@ fn test_zgemm_case(
     beta: Complex64,
 ) {
     // Determine matrix dimensions based on transpose
+    // For complex types, ConjNoTrans and ConjTrans are distinct
     let (a_rows, a_cols) = match transa {
-        CblasNoTrans => (m, k),
+        CblasNoTrans | CblasConjNoTrans => (m, k),
         CblasTrans | CblasConjTrans => (k, m),
     };
     let (b_rows, b_cols) = match transb {
-        CblasNoTrans => (k, n),
+        CblasNoTrans | CblasConjNoTrans => (k, n),
         CblasTrans | CblasConjTrans => (n, k),
     };
 

--- a/tests/gemv.rs
+++ b/tests/gemv.rs
@@ -1,0 +1,204 @@
+//! Pure-Rust layout tests for GEMV (complex types).
+//!
+//! Policy:
+//! - Do NOT modify existing OpenBLAS-derived tests.
+//! - Add additional tests that validate row-major conversion logic by comparing
+//!   `order=RowMajor` vs `order=ColMajor` results for the *same logical matrix*.
+//!
+//! Notes:
+//! - These tests still use OpenBLAS as the backend BLAS (via `blas_src`) for the
+//!   registered Fortran symbols, but the *test oracle* is purely internal:
+//!   RowMajor result must equal ColMajor result after providing equivalent inputs.
+
+extern crate blas_src;
+
+use cblas_inject::{
+    blasint, register_cgemv, register_zgemv, CblasColMajor, CblasConjTrans, CblasNoTrans,
+    CblasRowMajor, CblasTrans,
+};
+use num_complex::{Complex32, Complex64};
+use std::ffi::c_char;
+
+#[macro_use]
+mod common;
+use common::{assert_complex32_eq, assert_complex64_eq, x_len_gemv, y_len_gemv, Layout, Matrix};
+
+// Fortran BLAS function declarations (provided by linked OpenBLAS)
+extern "C" {
+    fn cgemv_(
+        trans: *const c_char,
+        m: *const blasint,
+        n: *const blasint,
+        alpha: *const Complex32,
+        a: *const Complex32,
+        lda: *const blasint,
+        x: *const Complex32,
+        incx: *const blasint,
+        beta: *const Complex32,
+        y: *mut Complex32,
+        incy: *const blasint,
+    );
+
+    fn zgemv_(
+        trans: *const c_char,
+        m: *const blasint,
+        n: *const blasint,
+        alpha: *const Complex64,
+        a: *const Complex64,
+        lda: *const blasint,
+        x: *const Complex64,
+        incx: *const blasint,
+        beta: *const Complex64,
+        y: *mut Complex64,
+        incy: *const blasint,
+    );
+}
+
+setup_once!(setup_cgemv, register_cgemv, cgemv_);
+setup_once!(setup_zgemv, register_zgemv, zgemv_);
+
+#[test]
+fn cgemv_row_vs_col_agree() {
+    setup_cgemv();
+
+    let cases = [
+        (1usize, 1usize),
+        (1, 3),
+        (3, 1),
+        (2, 3),
+        (3, 2),
+        (5, 7),
+    ];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let alpha = Complex32::new(0.7, 0.3);
+    let beta = Complex32::new(1.3, -0.5);
+
+    for &(m, n) in &cases {
+        for &trans in &transposes {
+            // Build the same logical matrix in both layouts, with padding LDA.
+            let a_row = Matrix::new_row_major(m, n, n + 2, |i, j| {
+                Complex32::new(((i + 3 * j) as f32 * 0.1).sin(), ((7 * i + j) as f32 * 0.2).cos())
+            });
+            let a_col = a_row.to_layout(Layout::ColMajor, m + 2);
+
+            let xl = x_len_gemv(trans, m, n);
+            let yl = y_len_gemv(trans, m, n);
+            let x: Vec<Complex32> = (0..xl)
+                .map(|k| Complex32::new(((k + 11) as f32 * 0.15).cos(), ((k + 5) as f32 * 0.25).sin()))
+                .collect();
+            let y0: Vec<Complex32> = (0..yl)
+                .map(|k| Complex32::new(((k + 17) as f32 * 0.05).sin(), ((k + 19) as f32 * 0.07).cos()))
+                .collect();
+
+            let mut y_row = y0.clone();
+            let mut y_col = y0.clone();
+
+            unsafe {
+                cblas_inject::cblas_cgemv(
+                    CblasRowMajor,
+                    trans,
+                    m as blasint,
+                    n as blasint,
+                    &alpha,
+                    a_row.as_ptr(),
+                    a_row.lda_blasint(),
+                    x.as_ptr(),
+                    1,
+                    &beta,
+                    y_row.as_mut_ptr(),
+                    1,
+                );
+                cblas_inject::cblas_cgemv(
+                    CblasColMajor,
+                    trans,
+                    m as blasint,
+                    n as blasint,
+                    &alpha,
+                    a_col.as_ptr(),
+                    a_col.lda_blasint(),
+                    x.as_ptr(),
+                    1,
+                    &beta,
+                    y_col.as_mut_ptr(),
+                    1,
+                );
+            }
+
+            let context = format!("cgemv row-vs-col: m={}, n={}, trans={:?}", m, n, trans);
+            assert_complex32_eq(&y_row, &y_col, 1e-5, &context);
+        }
+    }
+}
+
+#[test]
+fn zgemv_row_vs_col_agree() {
+    setup_zgemv();
+
+    let cases = [
+        (1usize, 1usize),
+        (1, 3),
+        (3, 1),
+        (2, 3),
+        (3, 2),
+        (5, 7),
+    ];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let alpha = Complex64::new(0.7, 0.3);
+    let beta = Complex64::new(1.3, -0.5);
+
+    for &(m, n) in &cases {
+        for &trans in &transposes {
+            let a_row = Matrix::new_row_major(m, n, n + 2, |i, j| {
+                Complex64::new(((i + 3 * j) as f64 * 0.1).sin(), ((7 * i + j) as f64 * 0.2).cos())
+            });
+            let a_col = a_row.to_layout(Layout::ColMajor, m + 2);
+
+            let xl = x_len_gemv(trans, m, n);
+            let yl = y_len_gemv(trans, m, n);
+            let x: Vec<Complex64> = (0..xl)
+                .map(|k| Complex64::new(((k + 11) as f64 * 0.15).cos(), ((k + 5) as f64 * 0.25).sin()))
+                .collect();
+            let y0: Vec<Complex64> = (0..yl)
+                .map(|k| Complex64::new(((k + 17) as f64 * 0.05).sin(), ((k + 19) as f64 * 0.07).cos()))
+                .collect();
+
+            let mut y_row = y0.clone();
+            let mut y_col = y0.clone();
+
+            unsafe {
+                cblas_inject::cblas_zgemv(
+                    CblasRowMajor,
+                    trans,
+                    m as blasint,
+                    n as blasint,
+                    &alpha,
+                    a_row.as_ptr(),
+                    a_row.lda_blasint(),
+                    x.as_ptr(),
+                    1,
+                    &beta,
+                    y_row.as_mut_ptr(),
+                    1,
+                );
+                cblas_inject::cblas_zgemv(
+                    CblasColMajor,
+                    trans,
+                    m as blasint,
+                    n as blasint,
+                    &alpha,
+                    a_col.as_ptr(),
+                    a_col.lda_blasint(),
+                    x.as_ptr(),
+                    1,
+                    &beta,
+                    y_col.as_mut_ptr(),
+                    1,
+                );
+            }
+
+            let context = format!("zgemv row-vs-col: m={}, n={}, trans={:?}", m, n, trans);
+            assert_complex64_eq(&y_row, &y_col, 1e-12, &context);
+        }
+    }
+}
+

--- a/tests/tbmv.rs
+++ b/tests/tbmv.rs
@@ -1,0 +1,227 @@
+//! Pure-Rust layout tests for TBMV (complex types).
+//!
+//! Policy:
+//! - Do NOT modify existing OpenBLAS-derived tests.
+//! - Add additional tests that validate row-major conversion logic by comparing
+//!   `order=RowMajor` vs `order=ColMajor` results for the *same logical triangular band matrix*.
+//!
+//! Key insight for band storage RowMajor conversion:
+//! - `RowMajor + Upper + NoTrans` internally becomes `ColMajor + Lower + Trans`
+//! - For the same logical matrix M, RowMajor storage must contain M^T with swapped uplo
+
+extern crate blas_src;
+
+use cblas_inject::{
+    blasint, register_ctbmv, register_ztbmv, CblasColMajor, CblasConjTrans, CblasLower,
+    CblasNoTrans, CblasNonUnit, CblasRowMajor, CblasTrans, CblasUpper,
+};
+use num_complex::{Complex32, Complex64};
+use std::ffi::c_char;
+
+#[macro_use]
+mod common;
+use common::{
+    assert_complex32_eq, assert_complex64_eq, create_triangular_band_matrix_col,
+    create_triangular_band_matrix_row,
+};
+
+// Fortran BLAS function declarations (provided by linked OpenBLAS)
+extern "C" {
+    fn ctbmv_(
+        uplo: *const c_char,
+        trans: *const c_char,
+        diag: *const c_char,
+        n: *const blasint,
+        k: *const blasint,
+        a: *const Complex32,
+        lda: *const blasint,
+        x: *mut Complex32,
+        incx: *const blasint,
+    );
+
+    fn ztbmv_(
+        uplo: *const c_char,
+        trans: *const c_char,
+        diag: *const c_char,
+        n: *const blasint,
+        k: *const blasint,
+        a: *const Complex64,
+        lda: *const blasint,
+        x: *mut Complex64,
+        incx: *const blasint,
+    );
+}
+
+setup_once!(setup_ctbmv, register_ctbmv, ctbmv_);
+setup_once!(setup_ztbmv, register_ztbmv, ztbmv_);
+
+#[test]
+fn ctbmv_row_vs_col_agree() {
+    setup_ctbmv();
+
+    let cases = [(3usize, 1usize), (4, 1), (5, 2)]; // (n, k)
+    let uplos = [CblasUpper, CblasLower];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let diags = [CblasNonUnit, cblas_inject::CblasUnit];
+
+    for &(n, k) in &cases {
+        for &uplo in &uplos {
+            for &trans in &transposes {
+                for &diag in &diags {
+                    // Create the same logical matrix M for both layouts
+                    let fill = |i: usize, j: usize| -> Complex32 {
+                        let is_triangular = match uplo {
+                            CblasUpper => i <= j,
+                            CblasLower => i >= j,
+                        };
+                        if is_triangular && (diag != cblas_inject::CblasUnit || i != j) {
+                            Complex32::new(
+                                ((i + 3 * j) as f32 * 0.1).sin(),
+                                ((7 * i + j) as f32 * 0.2).cos(),
+                            )
+                        } else if i == j {
+                            Complex32::new(1.0, 0.0) // diagonal for unit case
+                        } else {
+                            Complex32::new(0.0, 0.0)
+                        }
+                    };
+
+                    let a_col = create_triangular_band_matrix_col(n, k, uplo, fill);
+                    let a_row = create_triangular_band_matrix_row(n, k, uplo, fill);
+
+                    let x0: Vec<Complex32> = (0..n)
+                        .map(|k| {
+                            Complex32::new(
+                                ((k + 11) as f32 * 0.15).cos(),
+                                ((k + 5) as f32 * 0.25).sin(),
+                            )
+                        })
+                        .collect();
+
+                    let mut x_row = x0.clone();
+                    let mut x_col = x0.clone();
+
+                    let lda = (k + 1) as blasint;
+
+                    unsafe {
+                        cblas_inject::cblas_ctbmv(
+                            CblasRowMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            k as blasint,
+                            a_row.as_ptr(),
+                            lda,
+                            x_row.as_mut_ptr(),
+                            1,
+                        );
+                        cblas_inject::cblas_ctbmv(
+                            CblasColMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            k as blasint,
+                            a_col.as_ptr(),
+                            lda,
+                            x_col.as_mut_ptr(),
+                            1,
+                        );
+                    }
+
+                    let context = format!(
+                        "ctbmv row-vs-col: n={}, k={}, uplo={:?}, trans={:?}, diag={:?}",
+                        n, k, uplo, trans, diag
+                    );
+                    assert_complex32_eq(&x_row, &x_col, 1e-5, &context);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn ztbmv_row_vs_col_agree() {
+    setup_ztbmv();
+
+    let cases = [(3usize, 1usize), (4, 1), (5, 2)];
+    let uplos = [CblasUpper, CblasLower];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let diags = [CblasNonUnit, cblas_inject::CblasUnit];
+
+    for &(n, k) in &cases {
+        for &uplo in &uplos {
+            for &trans in &transposes {
+                for &diag in &diags {
+                    let fill = |i: usize, j: usize| -> Complex64 {
+                        let is_triangular = match uplo {
+                            CblasUpper => i <= j,
+                            CblasLower => i >= j,
+                        };
+                        if is_triangular && (diag != cblas_inject::CblasUnit || i != j) {
+                            Complex64::new(
+                                ((i + 3 * j) as f64 * 0.1).sin(),
+                                ((7 * i + j) as f64 * 0.2).cos(),
+                            )
+                        } else if i == j {
+                            Complex64::new(1.0, 0.0)
+                        } else {
+                            Complex64::new(0.0, 0.0)
+                        }
+                    };
+
+                    let a_col = create_triangular_band_matrix_col(n, k, uplo, fill);
+                    let a_row = create_triangular_band_matrix_row(n, k, uplo, fill);
+
+                    let x0: Vec<Complex64> = (0..n)
+                        .map(|k| {
+                            Complex64::new(
+                                ((k + 11) as f64 * 0.15).cos(),
+                                ((k + 5) as f64 * 0.25).sin(),
+                            )
+                        })
+                        .collect();
+
+                    let mut x_row = x0.clone();
+                    let mut x_col = x0.clone();
+
+                    let lda = (k + 1) as blasint;
+
+                    unsafe {
+                        cblas_inject::cblas_ztbmv(
+                            CblasRowMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            k as blasint,
+                            a_row.as_ptr(),
+                            lda,
+                            x_row.as_mut_ptr(),
+                            1,
+                        );
+                        cblas_inject::cblas_ztbmv(
+                            CblasColMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            k as blasint,
+                            a_col.as_ptr(),
+                            lda,
+                            x_col.as_mut_ptr(),
+                            1,
+                        );
+                    }
+
+                    let context = format!(
+                        "ztbmv row-vs-col: n={}, k={}, uplo={:?}, trans={:?}, diag={:?}",
+                        n, k, uplo, trans, diag
+                    );
+                    assert_complex64_eq(&x_row, &x_col, 1e-12, &context);
+                }
+            }
+        }
+    }
+}

--- a/tests/tbsv.rs
+++ b/tests/tbsv.rs
@@ -1,0 +1,230 @@
+//! Pure-Rust layout tests for TBSV (complex types).
+//!
+//! Policy:
+//! - Do NOT modify existing OpenBLAS-derived tests.
+//! - Add additional tests that validate row-major conversion logic by comparing
+//!   `order=RowMajor` vs `order=ColMajor` results for the *same logical triangular band matrix*.
+
+extern crate blas_src;
+
+use cblas_inject::{
+    blasint, register_ctbsv, register_ztbsv, CblasColMajor, CblasConjTrans, CblasLower,
+    CblasNoTrans, CblasNonUnit, CblasRowMajor, CblasTrans, CblasUpper,
+};
+use num_complex::{Complex32, Complex64};
+use std::ffi::c_char;
+
+#[macro_use]
+mod common;
+use common::{
+    assert_complex32_eq, assert_complex64_eq, create_triangular_band_matrix_col,
+    create_triangular_band_matrix_row,
+};
+
+// Fortran BLAS function declarations (provided by linked OpenBLAS)
+extern "C" {
+    fn ctbsv_(
+        uplo: *const c_char,
+        trans: *const c_char,
+        diag: *const c_char,
+        n: *const blasint,
+        k: *const blasint,
+        a: *const Complex32,
+        lda: *const blasint,
+        x: *mut Complex32,
+        incx: *const blasint,
+    );
+
+    fn ztbsv_(
+        uplo: *const c_char,
+        trans: *const c_char,
+        diag: *const c_char,
+        n: *const blasint,
+        k: *const blasint,
+        a: *const Complex64,
+        lda: *const blasint,
+        x: *mut Complex64,
+        incx: *const blasint,
+    );
+}
+
+setup_once!(setup_ctbsv, register_ctbsv, ctbsv_);
+setup_once!(setup_ztbsv, register_ztbsv, ztbsv_);
+
+#[test]
+fn ctbsv_row_vs_col_agree() {
+    setup_ctbsv();
+
+    let cases = [(3usize, 1usize), (4, 1), (5, 2)];
+    let uplos = [CblasUpper, CblasLower];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let diags = [CblasNonUnit, cblas_inject::CblasUnit];
+
+    for &(n, k) in &cases {
+        for &uplo in &uplos {
+            for &trans in &transposes {
+                for &diag in &diags {
+                    let fill = |i: usize, j: usize| -> Complex32 {
+                        let is_triangular = match uplo {
+                            CblasUpper => i <= j,
+                            CblasLower => i >= j,
+                        };
+                        if is_triangular {
+                            if diag == cblas_inject::CblasUnit && i == j {
+                                Complex32::new(1.0, 0.0)
+                            } else {
+                                let val = if i == j {
+                                    2.0 + ((i + j) as f32 * 0.1)
+                                } else {
+                                    ((i + 3 * j) as f32 * 0.1).sin()
+                                };
+                                Complex32::new(val, ((7 * i + j) as f32 * 0.2).cos())
+                            }
+                        } else {
+                            Complex32::new(0.0, 0.0)
+                        }
+                    };
+
+                    let a_col = create_triangular_band_matrix_col(n, k, uplo, fill);
+                    let a_row = create_triangular_band_matrix_row(n, k, uplo, fill);
+
+                    let x0: Vec<Complex32> = (0..n)
+                        .map(|k| {
+                            Complex32::new(
+                                ((k + 11) as f32 * 0.15).cos(),
+                                ((k + 5) as f32 * 0.25).sin(),
+                            )
+                        })
+                        .collect();
+
+                    let mut x_row = x0.clone();
+                    let mut x_col = x0.clone();
+
+                    let lda = (k + 1) as blasint;
+
+                    unsafe {
+                        cblas_inject::cblas_ctbsv(
+                            CblasRowMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            k as blasint,
+                            a_row.as_ptr(),
+                            lda,
+                            x_row.as_mut_ptr(),
+                            1,
+                        );
+                        cblas_inject::cblas_ctbsv(
+                            CblasColMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            k as blasint,
+                            a_col.as_ptr(),
+                            lda,
+                            x_col.as_mut_ptr(),
+                            1,
+                        );
+                    }
+
+                    let context = format!(
+                        "ctbsv row-vs-col: n={}, k={}, uplo={:?}, trans={:?}, diag={:?}",
+                        n, k, uplo, trans, diag
+                    );
+                    assert_complex32_eq(&x_row, &x_col, 1e-5, &context);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn ztbsv_row_vs_col_agree() {
+    setup_ztbsv();
+
+    let cases = [(3usize, 1usize), (4, 1), (5, 2)];
+    let uplos = [CblasUpper, CblasLower];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let diags = [CblasNonUnit, cblas_inject::CblasUnit];
+
+    for &(n, k) in &cases {
+        for &uplo in &uplos {
+            for &trans in &transposes {
+                for &diag in &diags {
+                    let fill = |i: usize, j: usize| -> Complex64 {
+                        let is_triangular = match uplo {
+                            CblasUpper => i <= j,
+                            CblasLower => i >= j,
+                        };
+                        if is_triangular {
+                            if diag == cblas_inject::CblasUnit && i == j {
+                                Complex64::new(1.0, 0.0)
+                            } else {
+                                let val = if i == j {
+                                    2.0 + ((i + j) as f64 * 0.1)
+                                } else {
+                                    ((i + 3 * j) as f64 * 0.1).sin()
+                                };
+                                Complex64::new(val, ((7 * i + j) as f64 * 0.2).cos())
+                            }
+                        } else {
+                            Complex64::new(0.0, 0.0)
+                        }
+                    };
+
+                    let a_col = create_triangular_band_matrix_col(n, k, uplo, fill);
+                    let a_row = create_triangular_band_matrix_row(n, k, uplo, fill);
+
+                    let x0: Vec<Complex64> = (0..n)
+                        .map(|k| {
+                            Complex64::new(
+                                ((k + 11) as f64 * 0.15).cos(),
+                                ((k + 5) as f64 * 0.25).sin(),
+                            )
+                        })
+                        .collect();
+
+                    let mut x_row = x0.clone();
+                    let mut x_col = x0.clone();
+
+                    let lda = (k + 1) as blasint;
+
+                    unsafe {
+                        cblas_inject::cblas_ztbsv(
+                            CblasRowMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            k as blasint,
+                            a_row.as_ptr(),
+                            lda,
+                            x_row.as_mut_ptr(),
+                            1,
+                        );
+                        cblas_inject::cblas_ztbsv(
+                            CblasColMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            k as blasint,
+                            a_col.as_ptr(),
+                            lda,
+                            x_col.as_mut_ptr(),
+                            1,
+                        );
+                    }
+
+                    let context = format!(
+                        "ztbsv row-vs-col: n={}, k={}, uplo={:?}, trans={:?}, diag={:?}",
+                        n, k, uplo, trans, diag
+                    );
+                    assert_complex64_eq(&x_row, &x_col, 1e-12, &context);
+                }
+            }
+        }
+    }
+}

--- a/tests/tpmv.rs
+++ b/tests/tpmv.rs
@@ -1,0 +1,398 @@
+//! Pure-Rust layout tests for TPMV and TPSV (complex types).
+//!
+//! Policy:
+//! - Do NOT modify existing OpenBLAS-derived tests.
+//! - Add additional tests that validate row-major conversion logic by comparing
+//!   `order=RowMajor` vs `order=ColMajor` results for the *same logical triangular packed matrix*.
+//!
+//! Key insight for packed storage RowMajor conversion:
+//! - `RowMajor + Upper + NoTrans` internally becomes `ColMajor + Lower + Trans`
+//! - For the same logical matrix M, RowMajor storage must contain M^T with swapped uplo
+
+extern crate blas_src;
+
+use cblas_inject::{
+    blasint, register_ctpmv, register_ctpsv, register_ztpmv, register_ztpsv, CblasColMajor,
+    CblasConjTrans, CblasLower, CblasNoTrans, CblasNonUnit, CblasRowMajor, CblasTrans, CblasUpper,
+};
+use num_complex::{Complex32, Complex64};
+use std::ffi::c_char;
+
+#[macro_use]
+mod common;
+use common::{
+    assert_complex32_eq, assert_complex64_eq, create_triangular_packed_matrix_col,
+    create_triangular_packed_matrix_row,
+};
+
+// Fortran BLAS function declarations (provided by linked OpenBLAS)
+extern "C" {
+    fn ctpmv_(
+        uplo: *const c_char,
+        trans: *const c_char,
+        diag: *const c_char,
+        n: *const blasint,
+        ap: *const Complex32,
+        x: *mut Complex32,
+        incx: *const blasint,
+    );
+
+    fn ztpmv_(
+        uplo: *const c_char,
+        trans: *const c_char,
+        diag: *const c_char,
+        n: *const blasint,
+        ap: *const Complex64,
+        x: *mut Complex64,
+        incx: *const blasint,
+    );
+
+    fn ctpsv_(
+        uplo: *const c_char,
+        trans: *const c_char,
+        diag: *const c_char,
+        n: *const blasint,
+        ap: *const Complex32,
+        x: *mut Complex32,
+        incx: *const blasint,
+    );
+
+    fn ztpsv_(
+        uplo: *const c_char,
+        trans: *const c_char,
+        diag: *const c_char,
+        n: *const blasint,
+        ap: *const Complex64,
+        x: *mut Complex64,
+        incx: *const blasint,
+    );
+}
+
+setup_once!(setup_ctpmv, register_ctpmv, ctpmv_);
+setup_once!(setup_ztpmv, register_ztpmv, ztpmv_);
+setup_once!(setup_ctpsv, register_ctpsv, ctpsv_);
+setup_once!(setup_ztpsv, register_ztpsv, ztpsv_);
+
+#[test]
+fn ctpmv_row_vs_col_agree() {
+    setup_ctpmv();
+
+    let cases = [1usize, 2, 3, 4, 5];
+    let uplos = [CblasUpper, CblasLower];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let diags = [CblasNonUnit, cblas_inject::CblasUnit];
+
+    for &n in &cases {
+        for &uplo in &uplos {
+            for &trans in &transposes {
+                for &diag in &diags {
+                    let fill = |i: usize, j: usize| -> Complex32 {
+                        let is_triangular = match uplo {
+                            CblasUpper => i <= j,
+                            CblasLower => i >= j,
+                        };
+                        if is_triangular && (diag != cblas_inject::CblasUnit || i != j) {
+                            Complex32::new(
+                                ((i + 3 * j) as f32 * 0.1).sin(),
+                                ((7 * i + j) as f32 * 0.2).cos(),
+                            )
+                        } else if i == j {
+                            Complex32::new(1.0, 0.0)
+                        } else {
+                            Complex32::new(0.0, 0.0)
+                        }
+                    };
+
+                    let ap_col = create_triangular_packed_matrix_col(n, uplo, fill);
+                    let ap_row = create_triangular_packed_matrix_row(n, uplo, fill);
+
+                    let x0: Vec<Complex32> = (0..n)
+                        .map(|k| {
+                            Complex32::new(
+                                ((k + 11) as f32 * 0.15).cos(),
+                                ((k + 5) as f32 * 0.25).sin(),
+                            )
+                        })
+                        .collect();
+
+                    let mut x_row = x0.clone();
+                    let mut x_col = x0.clone();
+
+                    unsafe {
+                        cblas_inject::cblas_ctpmv(
+                            CblasRowMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            ap_row.as_ptr(),
+                            x_row.as_mut_ptr(),
+                            1,
+                        );
+                        cblas_inject::cblas_ctpmv(
+                            CblasColMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            ap_col.as_ptr(),
+                            x_col.as_mut_ptr(),
+                            1,
+                        );
+                    }
+
+                    let context = format!(
+                        "ctpmv row-vs-col: n={}, uplo={:?}, trans={:?}, diag={:?}",
+                        n, uplo, trans, diag
+                    );
+                    assert_complex32_eq(&x_row, &x_col, 1e-5, &context);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn ztpmv_row_vs_col_agree() {
+    setup_ztpmv();
+
+    let cases = [1usize, 2, 3, 4, 5];
+    let uplos = [CblasUpper, CblasLower];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let diags = [CblasNonUnit, cblas_inject::CblasUnit];
+
+    for &n in &cases {
+        for &uplo in &uplos {
+            for &trans in &transposes {
+                for &diag in &diags {
+                    let fill = |i: usize, j: usize| -> Complex64 {
+                        let is_triangular = match uplo {
+                            CblasUpper => i <= j,
+                            CblasLower => i >= j,
+                        };
+                        if is_triangular && (diag != cblas_inject::CblasUnit || i != j) {
+                            Complex64::new(
+                                ((i + 3 * j) as f64 * 0.1).sin(),
+                                ((7 * i + j) as f64 * 0.2).cos(),
+                            )
+                        } else if i == j {
+                            Complex64::new(1.0, 0.0)
+                        } else {
+                            Complex64::new(0.0, 0.0)
+                        }
+                    };
+
+                    let ap_col = create_triangular_packed_matrix_col(n, uplo, fill);
+                    let ap_row = create_triangular_packed_matrix_row(n, uplo, fill);
+
+                    let x0: Vec<Complex64> = (0..n)
+                        .map(|k| {
+                            Complex64::new(
+                                ((k + 11) as f64 * 0.15).cos(),
+                                ((k + 5) as f64 * 0.25).sin(),
+                            )
+                        })
+                        .collect();
+
+                    let mut x_row = x0.clone();
+                    let mut x_col = x0.clone();
+
+                    unsafe {
+                        cblas_inject::cblas_ztpmv(
+                            CblasRowMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            ap_row.as_ptr(),
+                            x_row.as_mut_ptr(),
+                            1,
+                        );
+                        cblas_inject::cblas_ztpmv(
+                            CblasColMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            ap_col.as_ptr(),
+                            x_col.as_mut_ptr(),
+                            1,
+                        );
+                    }
+
+                    let context = format!(
+                        "ztpmv row-vs-col: n={}, uplo={:?}, trans={:?}, diag={:?}",
+                        n, uplo, trans, diag
+                    );
+                    assert_complex64_eq(&x_row, &x_col, 1e-12, &context);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn ctpsv_row_vs_col_agree() {
+    setup_ctpsv();
+
+    let cases = [1usize, 2, 3, 4, 5];
+    let uplos = [CblasUpper, CblasLower];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let diags = [CblasNonUnit, cblas_inject::CblasUnit];
+
+    for &n in &cases {
+        for &uplo in &uplos {
+            for &trans in &transposes {
+                for &diag in &diags {
+                    let fill = |i: usize, j: usize| -> Complex32 {
+                        let is_triangular = match uplo {
+                            CblasUpper => i <= j,
+                            CblasLower => i >= j,
+                        };
+                        if is_triangular {
+                            if diag == cblas_inject::CblasUnit && i == j {
+                                Complex32::new(1.0, 0.0)
+                            } else {
+                                let val = if i == j {
+                                    2.0 + ((i + j) as f32 * 0.1)
+                                } else {
+                                    ((i + 3 * j) as f32 * 0.1).sin()
+                                };
+                                Complex32::new(val, ((7 * i + j) as f32 * 0.2).cos())
+                            }
+                        } else {
+                            Complex32::new(0.0, 0.0)
+                        }
+                    };
+
+                    let ap_col = create_triangular_packed_matrix_col(n, uplo, fill);
+                    let ap_row = create_triangular_packed_matrix_row(n, uplo, fill);
+
+                    let x0: Vec<Complex32> = (0..n)
+                        .map(|k| {
+                            Complex32::new(
+                                ((k + 11) as f32 * 0.15).cos(),
+                                ((k + 5) as f32 * 0.25).sin(),
+                            )
+                        })
+                        .collect();
+
+                    let mut x_row = x0.clone();
+                    let mut x_col = x0.clone();
+
+                    unsafe {
+                        cblas_inject::cblas_ctpsv(
+                            CblasRowMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            ap_row.as_ptr(),
+                            x_row.as_mut_ptr(),
+                            1,
+                        );
+                        cblas_inject::cblas_ctpsv(
+                            CblasColMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            ap_col.as_ptr(),
+                            x_col.as_mut_ptr(),
+                            1,
+                        );
+                    }
+
+                    let context = format!(
+                        "ctpsv row-vs-col: n={}, uplo={:?}, trans={:?}, diag={:?}",
+                        n, uplo, trans, diag
+                    );
+                    assert_complex32_eq(&x_row, &x_col, 1e-5, &context);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn ztpsv_row_vs_col_agree() {
+    setup_ztpsv();
+
+    let cases = [1usize, 2, 3, 4, 5];
+    let uplos = [CblasUpper, CblasLower];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let diags = [CblasNonUnit, cblas_inject::CblasUnit];
+
+    for &n in &cases {
+        for &uplo in &uplos {
+            for &trans in &transposes {
+                for &diag in &diags {
+                    let fill = |i: usize, j: usize| -> Complex64 {
+                        let is_triangular = match uplo {
+                            CblasUpper => i <= j,
+                            CblasLower => i >= j,
+                        };
+                        if is_triangular {
+                            if diag == cblas_inject::CblasUnit && i == j {
+                                Complex64::new(1.0, 0.0)
+                            } else {
+                                let val = if i == j {
+                                    2.0 + ((i + j) as f64 * 0.1)
+                                } else {
+                                    ((i + 3 * j) as f64 * 0.1).sin()
+                                };
+                                Complex64::new(val, ((7 * i + j) as f64 * 0.2).cos())
+                            }
+                        } else {
+                            Complex64::new(0.0, 0.0)
+                        }
+                    };
+
+                    let ap_col = create_triangular_packed_matrix_col(n, uplo, fill);
+                    let ap_row = create_triangular_packed_matrix_row(n, uplo, fill);
+
+                    let x0: Vec<Complex64> = (0..n)
+                        .map(|k| {
+                            Complex64::new(
+                                ((k + 11) as f64 * 0.15).cos(),
+                                ((k + 5) as f64 * 0.25).sin(),
+                            )
+                        })
+                        .collect();
+
+                    let mut x_row = x0.clone();
+                    let mut x_col = x0.clone();
+
+                    unsafe {
+                        cblas_inject::cblas_ztpsv(
+                            CblasRowMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            ap_row.as_ptr(),
+                            x_row.as_mut_ptr(),
+                            1,
+                        );
+                        cblas_inject::cblas_ztpsv(
+                            CblasColMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            ap_col.as_ptr(),
+                            x_col.as_mut_ptr(),
+                            1,
+                        );
+                    }
+
+                    let context = format!(
+                        "ztpsv row-vs-col: n={}, uplo={:?}, trans={:?}, diag={:?}",
+                        n, uplo, trans, diag
+                    );
+                    assert_complex64_eq(&x_row, &x_col, 1e-12, &context);
+                }
+            }
+        }
+    }
+}

--- a/tests/trmv.rs
+++ b/tests/trmv.rs
@@ -1,0 +1,180 @@
+//! Pure-Rust layout tests for TRMV (complex types).
+//!
+//! Policy:
+//! - Do NOT modify existing OpenBLAS-derived tests.
+//! - Add additional tests that validate row-major conversion logic by comparing
+//!   `order=RowMajor` vs `order=ColMajor` results for the *same logical triangular matrix*.
+
+extern crate blas_src;
+
+use cblas_inject::{
+    blasint, register_ctrmv, register_ztrmv, CblasColMajor, CblasConjTrans, CblasLower,
+    CblasNoTrans, CblasNonUnit, CblasRowMajor, CblasTrans, CblasUpper,
+};
+use num_complex::{Complex32, Complex64};
+use std::ffi::c_char;
+
+#[macro_use]
+mod common;
+use common::{assert_complex32_eq, assert_complex64_eq, Layout, Matrix};
+
+// Fortran BLAS function declarations (provided by linked OpenBLAS)
+extern "C" {
+    fn ctrmv_(
+        uplo: *const c_char,
+        trans: *const c_char,
+        diag: *const c_char,
+        n: *const blasint,
+        a: *const Complex32,
+        lda: *const blasint,
+        x: *mut Complex32,
+        incx: *const blasint,
+    );
+
+    fn ztrmv_(
+        uplo: *const c_char,
+        trans: *const c_char,
+        diag: *const c_char,
+        n: *const blasint,
+        a: *const Complex64,
+        lda: *const blasint,
+        x: *mut Complex64,
+        incx: *const blasint,
+    );
+}
+
+setup_once!(setup_ctrmv, register_ctrmv, ctrmv_);
+setup_once!(setup_ztrmv, register_ztrmv, ztrmv_);
+
+#[test]
+fn ctrmv_row_vs_col_agree() {
+    setup_ctrmv();
+
+    let cases = [1usize, 2, 3, 4, 5];
+    let uplos = [CblasUpper, CblasLower];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let diags = [CblasNonUnit, cblas_inject::CblasUnit];
+
+    for &n in &cases {
+        for &uplo in &uplos {
+            for &trans in &transposes {
+                for &diag in &diags {
+                    // Create triangular matrix
+                    let a_row = Matrix::new_row_major(n, n, n + 2, |i, j| {
+                        let is_triangular = match uplo {
+                            CblasUpper => i <= j,
+                            CblasLower => i >= j,
+                        };
+                        if is_triangular && (diag != cblas_inject::CblasUnit || i != j) {
+                            Complex32::new(((i + 3 * j) as f32 * 0.1).sin(), ((7 * i + j) as f32 * 0.2).cos())
+                        } else {
+                            Complex32::new(0.0, 0.0)
+                        }
+                    });
+                    let a_col = a_row.to_layout(Layout::ColMajor, n + 2);
+
+                    let x0: Vec<Complex32> = (0..n)
+                        .map(|k| Complex32::new(((k + 11) as f32 * 0.15).cos(), ((k + 5) as f32 * 0.25).sin()))
+                        .collect();
+
+                    let mut x_row = x0.clone();
+                    let mut x_col = x0.clone();
+
+                    unsafe {
+                        cblas_inject::cblas_ctrmv(
+                            CblasRowMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            a_row.as_ptr(),
+                            a_row.lda_blasint(),
+                            x_row.as_mut_ptr(),
+                            1,
+                        );
+                        cblas_inject::cblas_ctrmv(
+                            CblasColMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            a_col.as_ptr(),
+                            a_col.lda_blasint(),
+                            x_col.as_mut_ptr(),
+                            1,
+                        );
+                    }
+
+                    let context = format!("ctrmv row-vs-col: n={}, uplo={:?}, trans={:?}, diag={:?}", n, uplo, trans, diag);
+                    assert_complex32_eq(&x_row, &x_col, 1e-5, &context);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn ztrmv_row_vs_col_agree() {
+    setup_ztrmv();
+
+    let cases = [1usize, 2, 3, 4, 5];
+    let uplos = [CblasUpper, CblasLower];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let diags = [CblasNonUnit, cblas_inject::CblasUnit];
+
+    for &n in &cases {
+        for &uplo in &uplos {
+            for &trans in &transposes {
+                for &diag in &diags {
+                    let a_row = Matrix::new_row_major(n, n, n + 2, |i, j| {
+                        let is_triangular = match uplo {
+                            CblasUpper => i <= j,
+                            CblasLower => i >= j,
+                        };
+                        if is_triangular && (diag != cblas_inject::CblasUnit || i != j) {
+                            Complex64::new(((i + 3 * j) as f64 * 0.1).sin(), ((7 * i + j) as f64 * 0.2).cos())
+                        } else {
+                            Complex64::new(0.0, 0.0)
+                        }
+                    });
+                    let a_col = a_row.to_layout(Layout::ColMajor, n + 2);
+
+                    let x0: Vec<Complex64> = (0..n)
+                        .map(|k| Complex64::new(((k + 11) as f64 * 0.15).cos(), ((k + 5) as f64 * 0.25).sin()))
+                        .collect();
+
+                    let mut x_row = x0.clone();
+                    let mut x_col = x0.clone();
+
+                    unsafe {
+                        cblas_inject::cblas_ztrmv(
+                            CblasRowMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            a_row.as_ptr(),
+                            a_row.lda_blasint(),
+                            x_row.as_mut_ptr(),
+                            1,
+                        );
+                        cblas_inject::cblas_ztrmv(
+                            CblasColMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            a_col.as_ptr(),
+                            a_col.lda_blasint(),
+                            x_col.as_mut_ptr(),
+                            1,
+                        );
+                    }
+
+                    let context = format!("ztrmv row-vs-col: n={}, uplo={:?}, trans={:?}, diag={:?}", n, uplo, trans, diag);
+                    assert_complex64_eq(&x_row, &x_col, 1e-12, &context);
+                }
+            }
+        }
+    }
+}

--- a/tests/trsv.rs
+++ b/tests/trsv.rs
@@ -1,0 +1,199 @@
+//! Pure-Rust layout tests for TRSV (complex types).
+//!
+//! Policy:
+//! - Do NOT modify existing OpenBLAS-derived tests.
+//! - Add additional tests that validate row-major conversion logic by comparing
+//!   `order=RowMajor` vs `order=ColMajor` results for the *same logical triangular matrix*.
+
+extern crate blas_src;
+
+use cblas_inject::{
+    blasint, register_ctrsv, register_ztrsv, CblasColMajor, CblasConjTrans, CblasLower,
+    CblasNoTrans, CblasNonUnit, CblasRowMajor, CblasTrans, CblasUpper,
+};
+use num_complex::{Complex32, Complex64};
+use std::ffi::c_char;
+
+#[macro_use]
+mod common;
+use common::{assert_complex32_eq, assert_complex64_eq, Layout, Matrix};
+
+// Fortran BLAS function declarations (provided by linked OpenBLAS)
+extern "C" {
+    fn ctrsv_(
+        uplo: *const c_char,
+        trans: *const c_char,
+        diag: *const c_char,
+        n: *const blasint,
+        a: *const Complex32,
+        lda: *const blasint,
+        x: *mut Complex32,
+        incx: *const blasint,
+    );
+
+    fn ztrsv_(
+        uplo: *const c_char,
+        trans: *const c_char,
+        diag: *const c_char,
+        n: *const blasint,
+        a: *const Complex64,
+        lda: *const blasint,
+        x: *mut Complex64,
+        incx: *const blasint,
+    );
+}
+
+setup_once!(setup_ctrsv, register_ctrsv, ctrsv_);
+setup_once!(setup_ztrsv, register_ztrsv, ztrsv_);
+
+#[test]
+fn ctrsv_row_vs_col_agree() {
+    setup_ctrsv();
+
+    let cases = [1usize, 2, 3, 4, 5];
+    let uplos = [CblasUpper, CblasLower];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let diags = [CblasNonUnit, cblas_inject::CblasUnit];
+
+    for &n in &cases {
+        for &uplo in &uplos {
+            for &trans in &transposes {
+                for &diag in &diags {
+                    // Create triangular matrix (must be non-singular)
+                    let a_row = Matrix::new_row_major(n, n, n + 2, |i, j| {
+                        let is_triangular = match uplo {
+                            CblasUpper => i <= j,
+                            CblasLower => i >= j,
+                        };
+                        if is_triangular {
+                            if diag == cblas_inject::CblasUnit && i == j {
+                                Complex32::new(1.0, 0.0) // Unit diagonal
+                            } else {
+                                // Ensure diagonal is non-zero for non-unit case
+                                let val = if i == j {
+                                    2.0 + ((i + j) as f32 * 0.1)
+                                } else {
+                                    ((i + 3 * j) as f32 * 0.1).sin()
+                                };
+                                Complex32::new(val, ((7 * i + j) as f32 * 0.2).cos())
+                            }
+                        } else {
+                            Complex32::new(0.0, 0.0)
+                        }
+                    });
+                    let a_col = a_row.to_layout(Layout::ColMajor, n + 2);
+
+                    let x0: Vec<Complex32> = (0..n)
+                        .map(|k| Complex32::new(((k + 11) as f32 * 0.15).cos(), ((k + 5) as f32 * 0.25).sin()))
+                        .collect();
+
+                    let mut x_row = x0.clone();
+                    let mut x_col = x0.clone();
+
+                    unsafe {
+                        cblas_inject::cblas_ctrsv(
+                            CblasRowMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            a_row.as_ptr(),
+                            a_row.lda_blasint(),
+                            x_row.as_mut_ptr(),
+                            1,
+                        );
+                        cblas_inject::cblas_ctrsv(
+                            CblasColMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            a_col.as_ptr(),
+                            a_col.lda_blasint(),
+                            x_col.as_mut_ptr(),
+                            1,
+                        );
+                    }
+
+                    let context = format!("ctrsv row-vs-col: n={}, uplo={:?}, trans={:?}, diag={:?}", n, uplo, trans, diag);
+                    assert_complex32_eq(&x_row, &x_col, 1e-5, &context);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn ztrsv_row_vs_col_agree() {
+    setup_ztrsv();
+
+    let cases = [1usize, 2, 3, 4, 5];
+    let uplos = [CblasUpper, CblasLower];
+    let transposes = [CblasNoTrans, CblasTrans, CblasConjTrans];
+    let diags = [CblasNonUnit, cblas_inject::CblasUnit];
+
+    for &n in &cases {
+        for &uplo in &uplos {
+            for &trans in &transposes {
+                for &diag in &diags {
+                    let a_row = Matrix::new_row_major(n, n, n + 2, |i, j| {
+                        let is_triangular = match uplo {
+                            CblasUpper => i <= j,
+                            CblasLower => i >= j,
+                        };
+                        if is_triangular {
+                            if diag == cblas_inject::CblasUnit && i == j {
+                                Complex64::new(1.0, 0.0)
+                            } else {
+                                let val = if i == j {
+                                    2.0 + ((i + j) as f64 * 0.1)
+                                } else {
+                                    ((i + 3 * j) as f64 * 0.1).sin()
+                                };
+                                Complex64::new(val, ((7 * i + j) as f64 * 0.2).cos())
+                            }
+                        } else {
+                            Complex64::new(0.0, 0.0)
+                        }
+                    });
+                    let a_col = a_row.to_layout(Layout::ColMajor, n + 2);
+
+                    let x0: Vec<Complex64> = (0..n)
+                        .map(|k| Complex64::new(((k + 11) as f64 * 0.15).cos(), ((k + 5) as f64 * 0.25).sin()))
+                        .collect();
+
+                    let mut x_row = x0.clone();
+                    let mut x_col = x0.clone();
+
+                    unsafe {
+                        cblas_inject::cblas_ztrsv(
+                            CblasRowMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            a_row.as_ptr(),
+                            a_row.lda_blasint(),
+                            x_row.as_mut_ptr(),
+                            1,
+                        );
+                        cblas_inject::cblas_ztrsv(
+                            CblasColMajor,
+                            uplo,
+                            trans,
+                            diag,
+                            n as blasint,
+                            a_col.as_ptr(),
+                            a_col.lda_blasint(),
+                            x_col.as_mut_ptr(),
+                            1,
+                        );
+                    }
+
+                    let context = format!("ztrsv row-vs-col: n={}, uplo={:?}, trans={:?}, diag={:?}", n, uplo, trans, diag);
+                    assert_complex64_eq(&x_row, &x_col, 1e-12, &context);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary\n- Fix complex ConjNoTrans handling in BLAS2 row-major conversions\n- Add DRY row/col layout tests (gemv/gbmv/trmv/trsv/tbmv/tbsv/tpmv)\n- Rename CI workflow and run Rust tests in CI\n\n## Testing\n- cargo test --test gemv --test gbmv --test trmv --test trsv --test tbmv --test tbsv --test tpmv\n\n## Notes\n- Untracked files (TEST_PLAN.md, extern/cblas-sys, test_lda) intentionally left out