### PR TITLE
Add cblas-sys compatibility test and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install openblas
 
+      - name: cblas-sys compatibility test
+        run: cargo test --test cblas_sys_compat
+        env:
+          LIBRARY_PATH: /opt/homebrew/opt/openblas/lib:/usr/local/opt/openblas/lib
+
       - name: Run Rust tests
         run: cargo test --release
         env:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This crate provides CBLAS-style functions (with row-major support) that internal
 
 ## Features
 
-- **cblas-sys compatible**: All 120 functions from cblas-sys are implemented
+- **cblas-sys compatible**: All 120 functions from cblas-sys are implemented. Can serve as a drop-in CBLAS provider for crates that depend on cblas-sys (see [below](#use-with-cblas-sys))
 - **Row-major support**: Handles row-major (C-style) data without memory copy for BLAS operations
 - **Partial registration**: Only register the functions you need
 - **Zero runtime overhead**: Uses `OnceLock` for minimal overhead (~0.5ns per call)
@@ -109,6 +109,47 @@ lib.register_dgemm(dgemm_ptr)
 # Now use cblas_dgemm
 # ... call lib.cblas_dgemm with ctypes
 ```
+
+### Use with cblas-sys
+
+cblas-inject can serve as the CBLAS implementation for crates that depend on
+[cblas-sys](https://crates.io/crates/cblas-sys). Since cblas-inject exports
+all CBLAS functions as `#[no_mangle] pub extern "C"` symbols, the linker
+resolves cblas-sys's `extern "C"` declarations to cblas-inject's implementations
+automatically.
+
+```toml
+[dependencies]
+cblas-sys = "0.1"
+cblas-inject = "0.1"
+```
+
+```rust
+use cblas_inject::register_dgemm;
+
+// Register Fortran BLAS pointer (from Python/Julia/etc.)
+unsafe { register_dgemm(dgemm_ptr); }
+
+// Now cblas_sys::cblas_dgemm calls cblas-inject's implementation
+unsafe {
+    cblas_sys::cblas_dgemm(
+        cblas_sys::CblasRowMajor,
+        cblas_sys::CblasNoTrans,
+        cblas_sys::CblasNoTrans,
+        m, n, k, alpha,
+        a.as_ptr(), lda,
+        b.as_ptr(), ldb,
+        beta,
+        c.as_mut_ptr(), ldc,
+    );
+}
+```
+
+This is useful when a third-party crate depends on cblas-sys and you want
+cblas-inject to provide the underlying CBLAS implementation.
+
+**Note:** Do not link another native CBLAS library (e.g., via `openblas-src`)
+at the same time, as this would cause duplicate symbol errors.
 
 ## Row-Major Handling
 

--- a/ctest/Makefile
+++ b/ctest/Makefile
@@ -61,7 +61,8 @@ dtestl3_driver = c_dblat3c.o
 ctestl3_driver = c_cblat3c.o
 ztestl3_driver = c_zblat3c.o
 
-.PHONY: all clean test test1 test2 test3 build-trampoline clone-openblas
+.PHONY: all clean test test1 test2 test3 build-trampoline clone-openblas \
+       _run-test1 _run-test2 _run-test3
 
 all: $(OPENBLAS_DIR) build-trampoline xscblat1 xdcblat1 xccblat1 xzcblat1 xscblat2 xdcblat2 xccblat2 xzcblat2 xscblat3 xdcblat3 xccblat3 xzcblat3
 
@@ -113,19 +114,31 @@ xccblat3: $(ctestl3_driver) $(ctestl3o)
 xzcblat3: $(ztestl3_driver) $(ztestl3o)
 	$(CC) -o $@ $^ $(LDFLAGS)
 
-test1: build-trampoline xscblat1 xdcblat1 xccblat1 xzcblat1
+# Use recursive make so that VPATH can find .c files after OpenBLAS is cloned.
+# Make resolves the full dependency graph before executing any commands, so
+# VPATH directories must exist at parse time for pattern rules to work.
+test1: $(OPENBLAS_DIR) build-trampoline
+	$(MAKE) _run-test1
+
+_run-test1: xscblat1 xdcblat1 xccblat1 xzcblat1
 	./xscblat1
 	./xdcblat1
 	./xccblat1
 	./xzcblat1
 
-test2: build-trampoline xscblat2 xdcblat2 xccblat2 xzcblat2
+test2: $(OPENBLAS_DIR) build-trampoline
+	$(MAKE) _run-test2
+
+_run-test2: xscblat2 xdcblat2 xccblat2 xzcblat2
 	./xscblat2 < $(OPENBLAS_CTEST)/sin2
 	./xdcblat2 < $(OPENBLAS_CTEST)/din2
 	./xccblat2 < $(OPENBLAS_CTEST)/cin2
 	./xzcblat2 < $(OPENBLAS_CTEST)/zin2
 
-test3: build-trampoline xscblat3 xdcblat3 xccblat3 xzcblat3
+test3: $(OPENBLAS_DIR) build-trampoline
+	$(MAKE) _run-test3
+
+_run-test3: xscblat3 xdcblat3 xccblat3 xzcblat3
 	./xscblat3 < $(OPENBLAS_CTEST)/sin3
 	./xdcblat3 < $(OPENBLAS_CTEST)/din3
 	./xccblat3 < $(OPENBLAS_CTEST)/cin3

--- a/tests/cblas_sys_compat.rs
+++ b/tests/cblas_sys_compat.rs
@@ -1,0 +1,168 @@
+//! Test that cblas-inject's `#[no_mangle]` symbols satisfy cblas-sys's `extern "C"` declarations.
+//!
+//! This test does NOT link any external BLAS library. Instead, it registers a
+//! hand-written Fortran dgemm_ with cblas-inject, then calls `cblas_sys::cblas_dgemm`
+//! to verify the linker resolves it to cblas-inject's implementation.
+
+// NOTE: We intentionally do NOT use `extern crate blas_src;` here.
+// No native CBLAS library is linked — cblas-inject is the sole provider
+// of the `cblas_dgemm` symbol that cblas-sys's extern declaration requires.
+
+use std::ffi::c_char;
+
+use cblas_inject::{blasint, register_dgemm};
+
+/// Minimal Fortran-style dgemm implementation for testing (column-major, NoTrans only).
+///
+/// Computes: C = alpha * A * B + beta * C  (column-major storage)
+unsafe extern "C" fn mock_dgemm(
+    _transa: *const c_char,
+    _transb: *const c_char,
+    m: *const blasint,
+    n: *const blasint,
+    k: *const blasint,
+    alpha: *const f64,
+    a: *const f64,
+    lda: *const blasint,
+    b: *const f64,
+    ldb: *const blasint,
+    beta: *const f64,
+    c: *mut f64,
+    ldc: *const blasint,
+) {
+    let m = *m as usize;
+    let n = *n as usize;
+    let k = *k as usize;
+    let alpha = *alpha;
+    let beta = *beta;
+    let lda = *lda as usize;
+    let ldb = *ldb as usize;
+    let ldc = *ldc as usize;
+
+    for j in 0..n {
+        for i in 0..m {
+            let mut sum = 0.0;
+            for p in 0..k {
+                sum += *a.add(i + p * lda) * *b.add(p + j * ldb);
+            }
+            let c_ptr = c.add(i + j * ldc);
+            *c_ptr = alpha * sum + beta * *c_ptr;
+        }
+    }
+}
+
+fn setup() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| unsafe {
+        register_dgemm(mock_dgemm);
+    });
+}
+
+/// Verify that `cblas_sys::cblas_dgemm` links to cblas-inject's implementation.
+///
+/// cblas-sys declares `extern "C" { fn cblas_dgemm(...); }` without providing
+/// an implementation. cblas-inject's `#[no_mangle] pub extern "C" fn cblas_dgemm`
+/// satisfies this declaration at link time.
+#[test]
+fn test_cblas_sys_dgemm_resolved_by_inject() {
+    setup();
+
+    // 2x2 row-major: C = A * B
+    // A = [[1, 2], [3, 4]]
+    // B = [[5, 6], [7, 8]]
+    let a = [1.0, 2.0, 3.0, 4.0];
+    let b = [5.0, 6.0, 7.0, 8.0];
+    let mut c = [0.0f64; 4];
+
+    unsafe {
+        cblas_sys::cblas_dgemm(
+            cblas_sys::CblasRowMajor,
+            cblas_sys::CblasNoTrans,
+            cblas_sys::CblasNoTrans,
+            2,
+            2,
+            2,
+            1.0,
+            a.as_ptr(),
+            2,
+            b.as_ptr(),
+            2,
+            0.0,
+            c.as_mut_ptr(),
+            2,
+        );
+    }
+
+    // C = [[1*5+2*7, 1*6+2*8], [3*5+4*7, 3*6+4*8]] = [[19, 22], [43, 50]]
+    assert_eq!(c, [19.0, 22.0, 43.0, 50.0]);
+}
+
+/// Also verify column-major works through cblas_sys.
+#[test]
+fn test_cblas_sys_dgemm_colmajor() {
+    setup();
+
+    // 2x2 column-major: C = A * B
+    // A = [[1, 3], [2, 4]] stored as [1, 2, 3, 4] (col-major)
+    // B = [[5, 7], [6, 8]] stored as [5, 6, 7, 8] (col-major)
+    let a = [1.0, 2.0, 3.0, 4.0]; // col-major: A = [[1,3],[2,4]]
+    let b = [5.0, 6.0, 7.0, 8.0]; // col-major: B = [[5,7],[6,8]]
+    let mut c = [0.0f64; 4];
+
+    unsafe {
+        cblas_sys::cblas_dgemm(
+            cblas_sys::CblasColMajor,
+            cblas_sys::CblasNoTrans,
+            cblas_sys::CblasNoTrans,
+            2,
+            2,
+            2,
+            1.0,
+            a.as_ptr(),
+            2,
+            b.as_ptr(),
+            2,
+            0.0,
+            c.as_mut_ptr(),
+            2,
+        );
+    }
+
+    // C = A*B = [[1*5+3*6, 1*7+3*8], [2*5+4*6, 2*7+4*8]] = [[23, 31], [34, 46]]
+    // col-major: [23, 34, 31, 46]
+    assert_eq!(c, [23.0, 34.0, 31.0, 46.0]);
+}
+
+/// Test with alpha and beta scaling through cblas_sys.
+#[test]
+fn test_cblas_sys_dgemm_alpha_beta() {
+    setup();
+
+    // C = 2.0 * A * B + 0.5 * C_init (row-major)
+    let a = [1.0, 0.0, 0.0, 1.0]; // identity
+    let b = [3.0, 4.0, 5.0, 6.0];
+    let mut c = [10.0, 20.0, 30.0, 40.0];
+
+    unsafe {
+        cblas_sys::cblas_dgemm(
+            cblas_sys::CblasRowMajor,
+            cblas_sys::CblasNoTrans,
+            cblas_sys::CblasNoTrans,
+            2,
+            2,
+            2,
+            2.0,
+            a.as_ptr(),
+            2,
+            b.as_ptr(),
+            2,
+            0.5,
+            c.as_mut_ptr(),
+            2,
+        );
+    }
+
+    // C = 2*I*B + 0.5*C_init = 2*B + 0.5*C_init
+    // = [[6+5, 8+10], [10+15, 12+20]] = [[11, 18], [25, 32]]
+    assert_eq!(c, [11.0, 18.0, 25.0, 32.0]);
+}


### PR DESCRIPTION
## Summary
- Add `tests/cblas_sys_compat.rs` that verifies cblas-inject`s `#[no_mangle]` symbols satisfy `cblas-sys`s `extern "C"` declarations at link time
- The test uses a mock Fortran dgemm (no OpenBLAS needed for linking) and calls `cblas_sys::cblas_dgemm`, which the linker resolves to cblas-inject implementation
- Document the "Use with cblas-sys" pattern in README
- Add CI step for the compatibility test

## Test plan
- [x] `cargo test --test cblas_sys_compat` passes locally (3 tests: row-major, col-major, alpha/beta scaling)
- [ ] CI passes on ubuntu-latest and macos-latest